### PR TITLE
fetch demographics and basic user separately

### DIFF
--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -29,8 +29,9 @@ const checkActiveUser = (req) => {
 	const sessionId = req.cookies[process.env['FT_COOKIE_NAME']];
 
 	if (!userUuid || !sessionId || !secureSessionId) {
-		return;
+		throw new Error('Invalid session');
 	}
+
 	return {
 		userUuid,
 		secureSessionId,
@@ -51,7 +52,7 @@ const getUserFormModel = (userUuid, access_token) => {
 		userProfileApi.getUserProfile(userUuid, access_token),
 		suds.getPseudonym([userUuid]),
 		(userProfile, pseudonym) => {
-			userProfile.user = _.extend({}, userProfile.user, {pseudonym: pseudonym[userUuid]});
+			userProfile.user = _.extend({}, userProfile, {pseudonym: pseudonym[userUuid]});
 			return userProfile;
 		}
 	);
@@ -79,7 +80,7 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 					    description: responsibility
 				    }
 			    }
-		    } = userProfile;
+			} = userProfile.user;
 
 	} catch(e) {
 		throw new IncompleteUserDataError();
@@ -132,7 +133,9 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 const getAccessToken = (sessionId) => {
 	const jar = request.jar();
 	const cookie = request.cookie(`${process.env['FT_SECURE_COOKIE_NAME']}=${sessionId}`);
+
 	jar.setCookie(cookie, authUrl);
+
 	return request({
 		uri: authUrl,
 		headers: {
@@ -168,10 +171,6 @@ const get = (req, res, next) => {
 	console.log('Dummy Log')
 
 	const activeUserData = checkActiveUser(req);
-
-	if (!activeUserData) {
-		throw new Error('Invalid session');
-	}
 
 	const { userUuid, secureSessionId } = activeUserData;
 

--- a/lib/services/userProfileApi.js
+++ b/lib/services/userProfileApi.js
@@ -28,7 +28,6 @@ const profileApiUrl = process.env['USER_PROFILE_API_URL'];
 const profileApiKey = process.env['USER_PROFILE_API_KEY'];
 
 const getUserProfile = (uuid, accessToken) => {
-
 	const options = {
 		headers: {
 			'X-Api-Key': profileApiKey,
@@ -37,10 +36,11 @@ const getUserProfile = (uuid, accessToken) => {
 	};
 
 	const url = profileApiUrl + uuid + '/profile/basic';
+	const urlDemographics = profileApiUrl + uuid + '/profile/demographics';
 
 	const timer = new Timer();
 
-	return fetch(url, options).then((res) => {
+	const basicUserData = fetch(url, options).then((res) => {
 		endTimer(timer);
 
 		if (!res.ok) {
@@ -49,6 +49,19 @@ const getUserProfile = (uuid, accessToken) => {
 
 		return res.json();
 	});
+
+	const userDemographics = fetch(urlDemographics, options).then((res) => {
+		endTimer(timer);
+
+		if (!res.ok) {
+			throw new UserProfileApiError(res.statusText, res.status, res.response);
+		}
+
+		return res.json();
+	});
+
+	return Promise.all([basicUserData, userDemographics])
+		.then(data => Object.assign({}, data[0], { demographics: data[1] }))
 };
 
 module.exports = {


### PR DESCRIPTION
This fixes the Unathorized issue reported here https://trello.com/c/vzGlGnCr/570-unable-to-sign-up-for-alphaville-longroom
NOTE that the phone number is no longer retrieved and displays blank for all users.
As a long term solution we should either:
* remove the phone number completely for this app
OR
* ask users to sign in if their session_s is more than 30 minutes old.

In either case we could fetch the user data from GraphQL API with just one call.