### PR TITLE
Display o-comments-beta when commentsTalkReplacement flag is on

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ charset = utf-8
 
 [{**.js,**.json}]
 indent_style = tab
+indent_size = 2
 trim_trailing_whitespace = true
 
 [*.sql]

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,7 +1,12 @@
 require('./assets');
 require('alphaville-ui');
 require('o-expander');
-require('o-comments');
+if (window.commentsTalkReplacement) {
+	// Temporary addition until the comments are replaced
+	require('o-comments-beta');
+} else {
+	require('o-comments');
+}
 require('o-comment-count');
 require('./lib/deleteButton');
 require('./lib/ads');

--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,8 @@
     "o-card": "^3.0.0",
     "tinymce": "^4.5.1",
     "o-comments": "^4.0.0",
-    "o-comment-count": "^0.3.8",
+		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.9",
+		"o-comment-count": "^0.3.8",
     "o-tooltip": "^3.1.2"
   }
 }

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -16,10 +16,15 @@ module.exports = function (req, res, next) {
 
 				// TODO: admin access
 				if (post.published || (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor))) {
+					// Temporary addition until the comments are replaced
+					const flags = req.cookies['next-flags'];
+					const commentsTalkReplacement = flags && flags.indexOf('commentsTalkReplacement:on') >= 0;
+
 					res.render('content', {
 						title: post.title + ' | Long Room | FT Alphaville',
 						article: post,
 						editAndDelete: (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor)) ? true : false,
+						commentsTalkReplacement,
 						alphavilleUiShareData: {
 							article: post.dataForShare,
 							position: 'bottom'

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -1,6 +1,11 @@
 {{#contentFor "head"}}
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/main.css" />
-
+{{#commentsTalkReplacement}}
+	<script>
+		// Temporary addition until the comments are replaced
+		window.commentsTalkReplacement = true;
+	</script>
+{{/commentsTalkReplacement}}
 	<script>
 		(function () {
 			ctmLoadScript({


### PR DESCRIPTION
A bit hacky way to render o-comments-beta instead of o-comments when the commentsTalkReplacement flags is turned on in toggler.

Wanted to keep it simple for now and that's why we are only checking the cookies. Therefore, it will only work when the flag is turned on in toggler. For development purposes, this should be enough, but it won't work if want to turn the flag on in flags-api and expect the new UI to be available in production.