### PR TITLE
Split comments service between Coral Talk and Livefyre

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,7 +1,7 @@
 require('./assets');
 require('alphaville-ui');
 require('o-expander');
-if (window.commentsTalkReplacement) {
+if (window.commentsTalkReplacement || window.commentsUseCoral) {
 	// Temporary addition until the comments are replaced
 	require('o-comments-beta');
 } else {

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,7 +1,7 @@
 require('./assets');
 require('alphaville-ui');
 require('o-expander');
-if (window.commentsTalkReplacement || window.commentsUseCoral) {
+if (window.commentsTalkReplacement || window.commentsUseCoralTalk) {
 	// Temporary addition until the comments are replaced
 	require('o-comments-beta');
 } else {

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -21,10 +21,10 @@ module.exports = function (req, res, next) {
 					const commentsTalkReplacement = flags && flags.indexOf(encodeURIComponent('commentsTalkReplacement:on')) >= 0;
 
 					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
-					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+					const commentsUseCoralTalkFlag = process.env.COMMENTS_USE_CORAL_TALK === 'true';
 					const publishedAt = post.published_at.toISOString();
 					let useCoralTalk = false;
-					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
+					if (commentsUseCoralMilestoneDate && commentsUseCoralTalkFlag && publishedAt > commentsUseCoralMilestoneDate) {
 						useCoralTalk = true;
 					}
 

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -20,10 +20,19 @@ module.exports = function (req, res, next) {
 					const flags = req.get('next-flags');
 					const commentsTalkReplacement = flags && flags.indexOf(encodeURIComponent('commentsTalkReplacement:on')) >= 0;
 
+					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
+					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+					const publishedAt = post.published_at.toISOString();
+					let useCoralTalk = false;
+					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
+						useCoralTalk = true;
+					}
+
 					res.render('content', {
 						title: post.title + ' | Long Room | FT Alphaville',
 						article: post,
 						editAndDelete: (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor)) ? true : false,
+						useCoralTalk,
 						commentsTalkReplacement,
 						alphavilleUiShareData: {
 							article: post.dataForShare,

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -8,7 +8,7 @@
 {{/commentsTalkReplacement}}
 {{#useCoralTalk}}
 	<script>
-		window.commentsUseCoral = true;
+		window.commentsUseCoralTalk = true;
 	</script>
 {{/useCoralTalk}}
 	<script>

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -6,6 +6,11 @@
 		window.commentsTalkReplacement = true;
 	</script>
 {{/commentsTalkReplacement}}
+{{#useCoralTalk}}
+	<script>
+		window.commentsUseCoral = true;
+	</script>
+{{/useCoralTalk}}
 	<script>
 		(function () {
 			ctmLoadScript({


### PR DESCRIPTION
For posts published after a certain date (which is not decided yet) we will start using Coral Talk.

This relies on two environment variables named COMMENTS_USE_CORAL_TALK and COMMENTS_USE_CORAL_MILESTONE_DATE.

COMMENTS_USE_CORAL_TALK needs to be set to `true` for this to work.

COMMENTS_USE_CORAL_MILESTONE_DATE defines at which point we start using Coral Talk. Posts published before that date will be rendered with Livefyre, and those that are published after that date will be rendered with Coral.

If COMMENTS_USE_CORAL_TALK is not true or COMMENTS_USE_CORAL_MILESTONE_DATE is not set, the page will render with Livefyre.