### PR TITLE
add Snyk to scripts and devDependencies

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,42 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  'npm:debug:20170905':
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-adapter > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-client > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-client > engine.io-client > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-parser > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-adapter > socket.io-parser > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-client > socket.io-parser > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > engine.io > debug:
+        patched: '2019-07-22T16:28:11.053Z'
+  'npm:lodash:20180130':
+    - alphaville-build-tools > origami-build-tools > karma > lodash:
+        patched: '2019-07-22T16:28:11.053Z'
+  'npm:ms:20170412':
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > engine.io > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-adapter > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-client > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-client > engine.io-client > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-parser > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-adapter > socket.io-parser > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'
+    - alphaville-build-tools > origami-build-tools > karma > socket.io > socket.io-client > socket.io-parser > debug > ms:
+        patched: '2019-07-22T16:28:11.053Z'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "postinstall": "gulp",
-    "start": "node ./bin/www"
+    "start": "node ./bin/www",
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "engines": {
     "node": "^8"
@@ -37,5 +38,8 @@
     "request-promise": "^4.1.1",
     "sanitize-html": "^1.13.0",
     "striptags": "^2.2.0"
+  },
+  "devDependencies": {
+    "snyk": "^1.167.0"
   }
 }


### PR DESCRIPTION
There's no circleci so I haven't added this part: `- run: npx snyk monitor --org=customer-products --project-name=Financial-Times/alphaville-longroom` as per the repo below:
https://github.com/Financial-Times/next-front-page/pull/2022/files