### PR TITLE
Send new posts to the comments new article lambda

### DIFF
--- a/lib/controllers/create.js
+++ b/lib/controllers/create.js
@@ -1,6 +1,33 @@
 "use strict";
 
+const request = require('request-promise');
 const db = require('../services/db').db;
+const Queue = require('bull');
+const newArticleQueue = new Queue('new article', process.env.REDIS_URL, {
+	defaultJobOptions: {
+		removeOnComplete: true
+	}
+});
+
+newArticleQueue.process(job => {
+	if (!job.data.id || !job.data.title) {
+		return Promise.resolve();
+	}
+	
+	return request({
+		uri: process.env.NEW_ARTICLE_LAMBDA_URL,
+		method: 'POST',
+		headers: {
+			'x-api-key': process.env.NEW_ARTICLE_LAMBDA_KEY
+		},
+		body: {
+			uuid: job.data.id,
+			webUrl: `https://www.ft.com/longroom/content/${job.data.id}`,
+			title: job.data.title 
+		},
+		json: true
+	});
+});
 
 const MAX_TAGS = 3;
 const MAX_TAG_LENGTH = 30;
@@ -24,7 +51,7 @@ exports.getWriteAPostForm = (req, res) => {
 
 exports.post = (req, res) => {
 	const validation = {};
-
+	
 	if (!req.userData) {
 		res.status(401);
 		return res.json({
@@ -204,6 +231,24 @@ exports.post = (req, res) => {
 
 					throw err;
 				});
+			}).then((postId) => {
+				if (process.env.ENVIRONMENT !== 'prod') {
+					return Promise.resolve(postId);
+				}
+				
+				newArticleQueue.add({
+					id: postId,
+					title: req.body.title.trim()
+				},{
+					attempts: 10,
+					backoff: {
+						type: 'exponential',
+						delay: 2000
+					}
+				});
+
+				return postId
+
 			}).then((postId) => {
 				res.json({
 					success: true,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bluebird": "^3.3.5",
     "body-parser": "^1.18.2",
     "bower": "^1.7.7",
+    "bull": "^3.10.0",
     "crypto": "0.0.3",
     "debug": "~2.2.0",
     "entities": "^1.1.1",


### PR DESCRIPTION
## What
When a new longroom post is created send its metadata it to the comments-new-article lambda. This will then create a new asset in Coral Talk for this page and associate any future comments on this page with that asset and its metadata.

## How
[Bull](https://github.com/OptimalBits/bull) has been used to create a Redis backed queue. This will allow the system to retry a few times if the request fails. This should provide some resilience against intermittent errors such as network failures.

We are talking to the Lambda via API Gateway and this has been set up with an API key for authentication.