### PR TITLE
Update o-comments-beta version to v6.0.0-beta.17

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "o-card": "^3.0.0",
     "tinymce": "^4.5.1",
     "o-comments": "^5.1.1",
-		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.12",
+		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.17",
     "o-tooltip": "^3.1.2"
   }
 }


### PR DESCRIPTION
We are going to delete `next-comments-auth-service` in favour of `next-comments-api`. With this update, o-comments-beta will use `next-comments-api` for authenticating users.