### PR TITLE
ADSDEV-165 Implement Permutive on Alphaville Longroom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+.vscode
 
 .env
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+-include .env
+
+.env:
+	heroku config -s  >> .env --app av2-longroom-test
+
+bower_components:
+	bower install
+
+node_modules:
+	npm install
+
+install-tools:
+	npm install -g bower; \
+	npm install -g gulp
+
+install: .env bower_components node_modules
+
+clean:
+	rm -rf .env bower_components node_modules
+
+run-dev: install
+	export SKIP_AUTH=true; \
+	heroku local -p 5001

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -8,4 +8,5 @@ if (window.commentsTalkReplacement || window.commentsUseCoralTalk) {
 	require('o-comments');
 }
 require('./lib/deleteButton');
+require('./lib/permutive');
 require('./lib/ads');

--- a/assets/js/lib/permutive.js
+++ b/assets/js/lib/permutive.js
@@ -1,0 +1,4 @@
+const Permutive = require('alphaville-ui')['permutive'];
+Permutive.initPermutive();
+Permutive.setUser();
+Permutive.setPermutiveSegments();

--- a/bower.json
+++ b/bower.json
@@ -1,36 +1,36 @@
 {
-  "name": "alphaville-longroom",
-  "description": "",
-  "main": "",
-  "authors": [
-    "Roland Vachter <roland.vachter@ft.com>"
-  ],
-  "homepage": "https://github.com/Financial-Times/alphaville-longroom",
-  "moduleType": [
-    "globals"
-  ],
-  "private": true,
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
-  "dependencies": {
-    "alphaville-ui": "Financial-Times/alphaville-ui#2.2.3",
-    "dom-delegate": "ftdomdelegate#^2.0.0",
-    "o-dom": "o-dom#^2.0.0",
-    "hogan": "twitter/hogan.js#^3.0.2",
-    "o-link-list": "^2.0.0",
-    "o-autoinit": "^1.3.0",
-    "o-forms": "^5.0.0",
-    "o-expander": "^4.0.0",
-    "awesomplete": "^1.1.1",
-    "o-card": "^3.0.0",
-    "tinymce": "^4.5.1",
-    "o-comments": "^5.1.1",
+	"name": "alphaville-longroom",
+	"description": "",
+	"main": "",
+	"authors": [
+		"Roland Vachter <roland.vachter@ft.com>"
+	],
+	"homepage": "https://github.com/Financial-Times/alphaville-longroom",
+	"moduleType": [
+		"globals"
+	],
+	"private": true,
+	"ignore": [
+		"**/.*",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	],
+	"dependencies": {
+		"alphaville-ui": "Financial-Times/alphaville-ui#ADSDEV-23_implement-permutive-on-alphaville",
+		"dom-delegate": "ftdomdelegate#^2.0.0",
+		"o-dom": "o-dom#^2.0.0",
+		"hogan": "twitter/hogan.js#^3.0.2",
+		"o-link-list": "^2.0.0",
+		"o-autoinit": "^1.3.0",
+		"o-forms": "^5.0.0",
+		"o-expander": "^4.0.0",
+		"awesomplete": "^1.1.1",
+		"o-card": "^3.0.0",
+		"tinymce": "^4.5.1",
+		"o-comments": "^5.1.1",
 		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.12",
-    "o-tooltip": "^3.1.2"
-  }
+		"o-tooltip": "^3.1.2"
+	}
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "Financial-Times/alphaville-ui#ADSDEV-23_implement-permutive-on-alphaville",
+		"alphaville-ui": "Financial-Times/alphaville-ui#^2.3.0",
 		"dom-delegate": "ftdomdelegate#^2.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",


### PR DESCRIPTION
See also https://jira.ft.com/browse/ADSDEV-165

We are replacing Krux with Permutive as Ads DMP.
This PR import a Permutive library from alphaville-ui - see also https://github.com/Financial-Times/alphaville-ui/pull/10.
Permutive is then initialised - before oAds starts requesting any ads from GPT - and identifies the user.