### PR TITLE
ADSDEV-83 Remove Krux from Alphaville

### DIFF
--- a/assets/js/lib/ads.js
+++ b/assets/js/lib/ads.js
@@ -1,4 +1,4 @@
-const oAds = require('alphaville-ui')['o-ads'];
+import { oAds } from 'alphaville-ui';
 
 function checkInArticleAd () {
 	const inArticleAd1 = document.querySelector('.alphaville-in-article-ad1');

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "Financial-Times/alphaville-ui#^2.3.0",
+		"alphaville-ui": "Financial-Times/alphaville-ui#^2.4.0",
 		"dom-delegate": "ftdomdelegate#^2.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",


### PR DESCRIPTION
See Jira https://jira.ft.com/browse/ADSDEV-83

* pin dependency alphaville-ui to ^2.4.0
* import o-ads using import instead of require