### PR TITLE
Upgrade the alphaville auth middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@financial-times/express-web-service": "^3.3.1",
     "@snyk/nodejs-runtime-agent": "^1.46.0",
-    "alphaville-auth-middleware": "Financial-Times/alphaville-auth-middleware#1.4.0",
+    "alphaville-auth-middleware": "Financial-Times/alphaville-auth-middleware#1.5.1",
     "alphaville-express": "Financial-Times/alphaville-express#1.1.1",
     "alphaville-header-config": "Financial-Times/alphaville-header-config#1.2.0",
     "alphaville-team-members": "Financial-Times/alphaville-team-members#1.0.0",


### PR DESCRIPTION
Use the latest version of the auth middleware which will allow the `SITE_FREE` decision