### PR TITLE
Split service between Livefyre and Coral Talk

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,8 +1,8 @@
 require('./assets');
 require('alphaville-ui');
 require('o-expander');
-if (window.commentsTalkReplacement || window.commentsUseCoralTalk) {
-	// Temporary addition until the comments are replaced
+// Temporary addition until the comments are replaced
+if (window.commentsUseCoralTalk) {
 	require('o-comments-beta');
 } else {
 	require('o-comments');

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "Financial-Times/alphaville-ui#^2.4.0",
+		"alphaville-ui": "Financial-Times/alphaville-ui#^2.5.0",
 		"dom-delegate": "ftdomdelegate#^2.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",
@@ -30,7 +30,7 @@
 		"o-card": "^3.0.0",
 		"tinymce": "^4.5.1",
 		"o-comments": "^5.1.1",
-		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.26",
+		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.36",
 		"o-tooltip": "^3.1.2"
 	}
 }

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -17,14 +17,12 @@ module.exports = function (req, res, next) {
 				// TODO: admin access
 				if (post.published || (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor))) {
 					// Temporary addition until the comments are replaced
-					const flags = req.get('next-flags');
-					const commentsTalkReplacement = flags && flags.indexOf(encodeURIComponent('commentsTalkReplacement:on')) >= 0;
-
 					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
-					const commentsUseCoralTalkFlag = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
 					const publishedAt = post.published_at.toISOString();
+
 					let useCoralTalk = false;
-					if (commentsUseCoralMilestoneDate && commentsUseCoralTalkFlag && publishedAt > commentsUseCoralMilestoneDate) {
+					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
 						useCoralTalk = true;
 					}
 
@@ -36,7 +34,6 @@ module.exports = function (req, res, next) {
 						editAndDelete: (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor)) ? true : false,
 						canonicalUrl,
 						useCoralTalk,
-						commentsTalkReplacement,
 						alphavilleUiShareData: {
 							article: post.dataForShare,
 							position: 'bottom'

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -96,7 +96,8 @@
 					id="comments"
 					data-o-component="o-comments"
 					data-o-comments-article-id="longroom{{article.id}}"
-					data-o-comments-story-url="{{article.webUrl}}">
+					data-o-comments-story-url="{{article.webUrl}}"
+					data-o-comments-source-app="alphaville-longroom-commentsUseCoralTalk">
 				</div>
 			{{else}}
 				<a name="comments"></a>

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -95,7 +95,7 @@
 				<div class="o-comments"
 					id="comments"
 					data-o-component="o-comments"
-					data-o-comments-article-id="longroom{{article.id}}"
+					data-o-comments-article-id="{{article.id}}"
 					data-o-comments-story-url="{{article.webUrl}}"
 					data-o-comments-source-app="alphaville-longroom-commentsUseCoralTalk">
 				</div>

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -1,12 +1,6 @@
 {{#contentFor "head"}}
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/main.css" />
 	<link rel="canonical" href="{{canonicalUrl}}" />
-{{#commentsTalkReplacement}}
-	<script>
-		// Temporary addition until the comments are replaced
-		window.commentsTalkReplacement = true;
-	</script>
-{{/commentsTalkReplacement}}
 {{#useCoralTalk}}
 	<script>
 		window.commentsUseCoralTalk = true;
@@ -96,9 +90,23 @@
 
 			{{> alphaville-ui/share/main alphavilleUiShareData}}
 
-
-			<a name="comments"></a>
-			<div id="comments" data-o-component="o-comments" data-o-comments-config-title="{{article.title}}" data-o-comments-config-url="{{article.webUrl}}" data-o-comments-config-articleId="longroom{{article.id}}"></div>
+			{{#if useCoralTalk}}
+				<a name="comments"></a>
+				<div class="o-comments"
+					id="comments"
+					data-o-component="o-comments"
+					data-o-comments-article-id="longroom{{article.id}}"
+					data-o-comments-story-url="{{article.webUrl}}">
+				</div>
+			{{else}}
+				<a name="comments"></a>
+				<div id="comments"
+					data-o-component="o-comments"
+					data-o-comments-config-title="{{article.title}}"
+					data-o-comments-config-url="{{article.webUrl}}"
+					data-o-comments-config-articleId="longroom{{article.id}}">
+				</div>
+			{{/if}}
 		</div>
 	</div>
 {{/lr_layout}}

--- a/views/partials/commentcount.handlebars
+++ b/views/partials/commentcount.handlebars
@@ -1,1 +1,18 @@
-<a href="{{@root/basePath}}/content/{{id}}#comments" class="alphaville-card--comment-counter" data-o-component="o-comments" data-o-comments-count data-o-comments-config-article-id="longroom{{id}}" data-o-comments-config-template="{count}" data-trackable="comment-count"></a>
+{{#if useCoralTalk}}
+	<a href="{{@root/basePath}}/content/{{id}}#comments"
+		class="o-comments alphaville-card--comment-counter"
+		data-o-component="o-comments"
+		data-o-comments-article-id="longroom{{id}}"
+		data-o-comments-count="true"
+		data-trackable="comment-count">
+	</a>
+{{else}}
+	<a href="{{@root/basePath}}/content/{{id}}#comments"
+		class="alphaville-card--comment-counter"
+		data-o-component="o-comments"
+		data-o-comments-count
+		data-o-comments-config-article-id="longroom{{id}}"
+		data-o-comments-config-template="{count}"
+		data-trackable="comment-count">
+	</a>
+{{/if}}


### PR DESCRIPTION
Stories that are older than the `COMMENTS_USE_CORAL_MILESTONE_DATE` will
render `o-comments` v5 while stories after that date will render
`o-comments` v6.

To test, set `COMMENTS_USE_CORAL_TALK=true` and
`COMMENTS_USE_CORAL_MILESTONE_DATE=2019-09-26T00:00:00.000Z` in the .env
file. Then run the app locally and you should see Coral rendered on
articles published today and Livefyre rendered on articles published
yesterday.