### PR TITLE
Use comments-api to get display name (aka pseudonym)

### DIFF
--- a/lib/controllers/author.js
+++ b/lib/controllers/author.js
@@ -3,7 +3,7 @@
 const db = require('../services/db').db;
 const pagination = require('../utils/pagination');
 const postsDbTransformation = require('../dbNormalizers/posts');
-const sudsService = require('../services/suds');
+const commentsApi = require('../services/commentsApi');
 const Promise = require('bluebird');
 
 const itemsPerPage = 30;
@@ -31,12 +31,12 @@ module.exports = function (req, res, next) {
 	const isAdmin = req.userData.is_editor;
 
 
-	return Promise.join(db.user.find(userId), sudsService.getPseudonym([userId]), (lrUser, pseudonyms) => {
+	return Promise.join(db.user.find(userId), commentsApi.getUser(userId), (lrUser, commentsUser) => {
 		if (!lrUser) {
 			return next();
 		}
 
-		const pseudonym = pseudonyms[userId];
+		const pseudonym = commentsUser.displayName;
 
 		const viewData = {
 			title: `${pseudonym} | Long Room | FT Alphaville`,

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -6,6 +6,7 @@ const userProfileApi = require('../services/userProfileApi');
 const db = require('../services/db').db;
 const crypto = require('../services/crypto');
 const suds = require('../services/suds');
+const commentsApi = require('../services/commentsApi');
 
 const authUrl = process.env['AUTHORIZE_PATH'];
 const authParams = {
@@ -50,9 +51,9 @@ const updatePseudonym = (sessionId, formData) => {
 const getUserFormModel = (userUuid, access_token) => {
 	return Promise.join(
 		userProfileApi.getUserProfile(userUuid, access_token),
-		suds.getPseudonym([userUuid]),
-		(userProfile, pseudonym) => {
-			userProfile.user = _.extend({}, userProfile, {pseudonym: pseudonym[userUuid]});
+		commentsApi.getUser(userUuid),
+		(userProfile, commentsUser) => {
+			userProfile.user = _.extend({}, userProfile, {pseudonym: commentsUser.displayName});
 			return userProfile;
 		}
 	);
@@ -311,7 +312,7 @@ const setPseudonym = (req, res) => {
 	};
 
 	if (!req.body.pseudonym) {
-		validation.pseudonym = 'Pseudonym should not be empty.';
+		validation.pseudonym = 'Display name should not be empty.';
 	}
 
 	if (validation.pseudonym) {
@@ -323,7 +324,7 @@ const setPseudonym = (req, res) => {
 		});
 	} else {
 		suds.setPseudonym(req.body.pseudonym, req.cookies['FTSession']).then(() => {
-			res.setFlashMessage('success', 'Your pseudonym is successfully saved.');
+			res.setFlashMessage('success', 'Your display name is successfully saved.');
 			res.redirect(req.query.redirect || '/longroom/home');
 		}).catch((err) => {
 			const p = new Promise((resolve) => {

--- a/lib/dbNormalizers/posts.js
+++ b/lib/dbNormalizers/posts.js
@@ -1,7 +1,7 @@
 const objectInArray = require('../utils/objectInArray');
 const _ = require('lodash');
 const fileTypes = require('../utils/fileTypes');
-const sudsService = require('../services/suds');
+const commentsApi = require('../services/commentsApi');
 const sanitizeHtml = require('sanitize-html');
 const entities = require('entities');
 
@@ -179,14 +179,14 @@ exports.enrichWithPseudonyms = function (posts) {
 		return Promise.resolve(posts);
 	}
 
-	return sudsService.getPseudonym(userIds).then(pseudonyms => {
+	return commentsApi.getMultipleUsers(userIds).then(users => {
 		posts.forEach(post => {
 			if (!post.user) {
 				post.user = {};
 			}
 
-			if (pseudonyms[post.user_id]) {
-				post.user.pseudonym = pseudonyms[post.user_id];
+			if (users[post.user_id]) {
+				post.user.pseudonym = users[post.user_id];
 			} else {
 				post.user.pseudonym = '-';
 			}

--- a/lib/dbNormalizers/posts.js
+++ b/lib/dbNormalizers/posts.js
@@ -185,8 +185,8 @@ exports.enrichWithPseudonyms = function (posts) {
 				post.user = {};
 			}
 
-			if (users[post.user_id]) {
-				post.user.pseudonym = users[post.user_id];
+			if (users[post.user_id] && users[post.user_id].displayName) {
+				post.user.pseudonym = users[post.user_id].displayName;
 			} else {
 				post.user.pseudonym = '-';
 			}

--- a/lib/health/healthServices/commentsApi.js
+++ b/lib/health/healthServices/commentsApi.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const _ = require('lodash');
+
+const commentsApi = require('../../services/commentsApi');
+const commentsApiUrl = process.env.COMMENTS_API_URL;
+
+const healthCheckModel = {
+	id: 'comments-api',
+	name: 'Next comments API',
+	ok: false,
+	technicalSummary: "Used for fetching user's display name.",
+	severity: 2,
+	businessImpact: "Display names will not be available for the application. Dashboard page will be unreachable.",
+	checkOutput: "",
+	panicGuide: `Check the healthcheck of the service (https://${commentsApiUrl}/__health)`,
+	lastUpdated: new Date().toISOString()
+};
+
+exports.getHealth = function () {
+	return new Promise((resolve) => {
+		const currentHealth = _.clone(healthCheckModel);
+
+		commentsApi.getUser(process.env.HEALTH_USER_ID)
+			.then(() => {
+				currentHealth.ok = true;
+				resolve(_.omit(currentHealth, ['checkOutput']));
+			})
+			.catch((err) => {
+				currentHealth.ok = false;
+				currentHealth.checkOutput = "Comments API is unreachable. Error: " + (err && err.message ? err.message : '');
+				resolve(currentHealth);
+			});
+	});
+};

--- a/lib/health/healthServices/sudsApi.js
+++ b/lib/health/healthServices/sudsApi.js
@@ -9,9 +9,9 @@ const healthCheckModel = {
 	id: 'suds',
 	name: 'Session user data service',
 	ok: false,
-	technicalSummary: "Used for fetching and setting user's pseudonym.",
+	technicalSummary: "Used for setting user's pseudonym.",
 	severity: 2,
-	businessImpact: "Pseudonyms will not be available for the application. Dashboard page will be unreachable, users without pseudonym won't be able to access the application.",
+	businessImpact: "Users without pseudonym won't be able to access the application.",
 	checkOutput: "",
 	panicGuide: `Check the healthcheck of the service (https://${sudsApiUrl}/__health)`,
 	lastUpdated: new Date().toISOString()

--- a/lib/health/healthchecks.js
+++ b/lib/health/healthchecks.js
@@ -7,6 +7,7 @@ const healthServices = [
 	require('./healthServices/userSessionApi'),
 	require('./healthServices/recentCommentsApi'),
 	require('./healthServices/sudsApi'),
+	require('./healthServices/commentsApi'),
 	require('./healthServices/userProfileApi'),
 	require('./healthServices/awsS3'),
 	require('./healthServices/als')

--- a/lib/middlewares/checkPseudonym.js
+++ b/lib/middlewares/checkPseudonym.js
@@ -1,12 +1,12 @@
 const db = require('../services/db').db;
-const sudsService = require('../services/suds');
+const commentsApi = require('../services/commentsApi');
 
 module.exports = function (req, res, next) {
 	if (req.userData) {
 		if (!req.userData.has_pseudonym) {
-			return sudsService.getPseudonym([req.userData.user_id]).then(data => {
-				if (data && data[req.userData.user_id]) {
-					req.userData.pseudonym = data[req.userData.user_id];
+			return commentsApi.getUser(req.userData.user_id).then(data => {
+				if (data && data.displayName) {
+					req.userData.pseudonym = data.displayName;
 
 					db.user.updatePseudonymFlag({
 						id: req.userData.user_id,

--- a/lib/middlewares/fetchPseudonym.js
+++ b/lib/middlewares/fetchPseudonym.js
@@ -1,12 +1,12 @@
 const db = require('../services/db').db;
-const sudsService = require('../services/suds');
+const commentsApi = require('../services/commentsApi');
 
 module.exports = function (req, res, next) {
 	if (req.userData) {
 		if (!req.userData.pseudonym) {
-			return sudsService.getPseudonym([req.userData.user_id]).then(data => {
-				if (data && data[req.userData.user_id]) {
-					req.userData.pseudonym = data[req.userData.user_id];
+			return commentsApi.getUser(req.userData.user_id).then(data => {
+				if (data && data.displayName) {
+					req.userData.pseudonym = data.displayName;
 				}
 
 				next();

--- a/lib/services/commentsApi.js
+++ b/lib/services/commentsApi.js
@@ -1,0 +1,43 @@
+const fetch = require('node-fetch');
+
+function CommentsApiError(message, code, response) {
+	this.statusText = message;
+	this.message = message;
+	this.errMsg = message;
+
+	this.code = code;
+	this.errCode = code;
+	this.status = code;
+
+	this.response = response;
+}
+CommentsApiError.prototype = new Error('commentsApi');
+
+exports.getUser = userId => {
+	const options = {
+		headers: {
+			'X-Api-Key': process.env.COMMENTS_API_KEY
+		}
+	};
+
+	const url = `${process.env.COMMENTS_API_URL}/user/${userId}`;
+
+	return fetch(url, options).then((res) => {
+		if (!res.ok && !(res.status === 404)) {
+			throw new CommentsApiError(res.statusText, res.status, res);
+		}
+		return res.json();
+	});
+};
+
+exports.getMultipleUsers = userIds => {
+	const promises = userIds.map(id => exports.getUser(id));
+
+	return Promise.all(promises)
+		.then(responses => {
+			return responses.reduce((accumulator, next) => {
+				accumulator[next.userId] = next.displayName;
+				return accumulator
+			}, {});
+		});
+};

--- a/lib/services/commentsApi.js
+++ b/lib/services/commentsApi.js
@@ -36,7 +36,7 @@ exports.getMultipleUsers = userIds => {
 	return Promise.all(promises)
 		.then(responses => {
 			return responses.reduce((accumulator, next) => {
-				accumulator[next.userId] = next.displayName;
+				accumulator[next.userId] = next;
 				return accumulator
 			}, {});
 		});

--- a/lib/services/suds.js
+++ b/lib/services/suds.js
@@ -17,23 +17,6 @@ function SudsApiError(message, code, response) {
 }
 SudsApiError.prototype = new Error('sudsApi');
 
-exports.getPseudonym = (userIds) => {
-	const options = {
-		headers: {
-			'X-Api-Key': process.env.SUDS_API_KEY
-		}
-	};
-
-	const url = `${sudsUserUrl}/getPseudonym?userIds=${userIds.join(',')}`;
-
-	return fetch(url, options).then((res) => {
-		if (!res.ok) {
-			throw new SudsApiError(res.statusText, res.status, res);
-		}
-		return res.json();
-	});
-};
-
 exports.setPseudonym = (pseudonym, sessionId) => {
 	const options = {
 		method: 'POST',

--- a/views/joinForm.handlebars
+++ b/views/joinForm.handlebars
@@ -34,7 +34,7 @@
 		<div class="o-grid-row">
 			{{#if errors.pseudonym}}
 				<div class="o-forms o-forms--error" data-o-grid-colspan="12">
-					<label class="o-forms__label" for="pseudonym">Pseudonym *</label>
+					<label class="o-forms__label" for="pseudonym">Display name *</label>
 					<div class="o-forms__additional-info">This will also be used for comments and posts</div>
 					<input type="text" class="o-forms__text" name="pseudonym" value="{{pseudonym}}" />
 					{{#each errors.pseudonym}}
@@ -43,7 +43,7 @@
 				</div>
 			{{else}}
 				<div class="o-forms" data-o-grid-colspan="12">
-					<label class="o-forms__label" for="pseudonym">Pseudonym *</label>
+					<label class="o-forms__label" for="pseudonym">Display name *</label>
 					<div class="o-forms__additional-info">This will also be used for comments and posts</div>
 					<input type="text" class="o-forms__text" name="pseudonym" value="{{pseudonym}}" />
 				</div>

--- a/views/setPseudonymForm.handlebars
+++ b/views/setPseudonymForm.handlebars
@@ -15,14 +15,14 @@
 	<div class="o-grid-row">
 		<div data-o-grid-colspan="12 M11 XL10 XLoffset2" class="lr-form lr-pseudonym-form">
 
-		<h1 class="lr-page-heading">Set a pseudonym</h1>
+		<h1 class="lr-page-heading">Set a display name</h1>
 
 			<form action="{{basePath}}/user/setpseudonym?redirect={{redirect}}" method="POST">
-				<p>As a Long Room member, you need a public pseudonym -- and you don't seem to have one.</p>
+				<p>As a Long Room member, you need a public display name -- and you don't seem to have one.</p>
 				<p>Make up a name for yourself below and then just click save.</p>
 
 				<div class="o-forms">
-					<label class="o-forms__label" for="pseudonym">Pseudonym</label>
+					<label class="o-forms__label" for="pseudonym">Display name</label>
 					<input type="text" class="o-forms__text" name="pseudonym" id="pseudonym" value="{{pseudonym}}" />
 					{{#validation}}<div class="o-forms__errortext">{{{pseudonym}}}</div>{{/validation}}
 				</div>


### PR DESCRIPTION
Coral Talk will be the single source of truth for display names in the future. With this PR, we use comments-api to get display names for users, which uses Coral and SUDS to find display names (precedence is given to Coral).

We also change all references to the term *"pseudonym"* to *"display name"* in the UI.

**NOTE:**
Longroom is still using SUDS to set display names when a user logs in for the first time and doesn't have a display name yet.

Because comments-api also uses SUDS as a source, this feature will not break with this PR.

Currently, Coral doesn't have an API to create SSO users. The only way of doing that is by using the embed script at the client side.

We need to speak to Coral team for this and revisit Longroom when it is doable.