### PR TITLE
ADSDEV-226 Alphaville - Pageview event not passed to Permutive

### DIFF
--- a/assets/js/lib/permutive.js
+++ b/assets/js/lib/permutive.js
@@ -1,4 +1,6 @@
+const contentId = document.documentElement.dataset.contentId;
 const Permutive = require('alphaville-ui')['permutive'];
+
 Permutive.initPermutive();
-Permutive.setUser();
+Permutive.setUserAndContent(contentId);
 Permutive.setPermutiveSegments();

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "Financial-Times/alphaville-ui#^2.5.0",
+		"alphaville-ui": "git@github.com:Financial-Times/alphaville-ui.git#ADSDEV-226_Alphaville_Pageview_event_not_passed_to_Permutive",
 		"dom-delegate": "ftdomdelegate#^2.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",


### PR DESCRIPTION
This is part of Jira ticket [#226 Alphaville - Pageview event not passed to Permutive](https://financialtimes.atlassian.net/browse/ADSDEV-226?atlOrigin=eyJpIjoiY2I4ZGE3MzY1MGZlNDZiY2ExMWM4NTg5Y2ZlOWM5MzQiLCJwIjoiaiJ9ADSDEV-226)

## Description
`Permutive` is not working properly on Alphaville, specifically it is not firing the `PageView` event from Alphaville.

## Changes
Set user and page metadata in `common.js`.
