### PR TITLE
Update webUrl passed onto create article lambda

### DIFF
--- a/lib/controllers/create.js
+++ b/lib/controllers/create.js
@@ -13,7 +13,9 @@ newArticleQueue.process(job => {
 	if (!job.data.id || !job.data.title) {
 		return Promise.resolve();
 	}
-	
+
+	const webUrl = process.env.APP_URL + `content/${job.data.id}`;
+
 	return request({
 		uri: process.env.NEW_ARTICLE_LAMBDA_URL,
 		method: 'POST',
@@ -22,8 +24,8 @@ newArticleQueue.process(job => {
 		},
 		body: {
 			uuid: job.data.id,
-			webUrl: `https://www.ft.com/longroom/content/${job.data.id}`,
-			title: job.data.title 
+			webUrl,
+			title: job.data.title
 		},
 		json: true
 	});
@@ -51,7 +53,7 @@ exports.getWriteAPostForm = (req, res) => {
 
 exports.post = (req, res) => {
 	const validation = {};
-	
+
 	if (!req.userData) {
 		res.status(401);
 		return res.json({
@@ -235,7 +237,7 @@ exports.post = (req, res) => {
 				if (process.env.ENVIRONMENT !== 'prod') {
 					return Promise.resolve(postId);
 				}
-				
+
 				newArticleQueue.add({
 					id: postId,
 					title: req.body.title.trim()

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -26,7 +26,7 @@ module.exports = function (req, res, next) {
 						useCoralTalk = true;
 					}
 
-					const canonicalUrl = `https://ftalphaville.ft.com/longroom/content/${post.id}`;
+					const canonicalUrl = process.env.APP_URL + `/content/${post.id}`;
 
 					res.render('content', {
 						title: post.title + ' | Long Room | FT Alphaville',


### PR DESCRIPTION
We've been using the incorrect one, rather than `www.ft.com` we should
be using `www.ftalphaville.ft.com`. The result was that we were seeing a `DUPLICATE_STORY_ID` error on Alphaville Longroom articles.