### PR TITLE
Use `path.join` instead to append id to webUrl

### DIFF
--- a/lib/controllers/create.js
+++ b/lib/controllers/create.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const path = require('path');
 const request = require('request-promise');
 const db = require('../services/db').db;
 const Queue = require('bull');
@@ -14,7 +15,7 @@ newArticleQueue.process(job => {
 		return Promise.resolve();
 	}
 
-	const webUrl = process.env.APP_URL + `content/${job.data.id}`;
+	const webUrl = path.join(process.env.APP_URL,`content/${job.data.id}`);
 
 	return request({
 		uri: process.env.NEW_ARTICLE_LAMBDA_URL,

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const db = require('../services/db').db;
+const path = require('path');
 
 module.exports = function (req, res, next) {
 	if (req.params.id) {
@@ -26,7 +27,7 @@ module.exports = function (req, res, next) {
 						useCoralTalk = true;
 					}
 
-					const canonicalUrl = process.env.APP_URL + `/content/${post.id}`;
+					const canonicalUrl = path.join(process.env.APP_URL, `/content/${post.id}`);
 
 					res.render('content', {
 						title: post.title + ' | Long Room | FT Alphaville',


### PR DESCRIPTION
It ensures that the url is constructed correctly (e.g. we have the
correct `/` in place).

Related to PR: https://github.com/Financial-Times/alphaville-longroom/pull/36