### PR TITLE
Only show Coral comment count after migration date

### DIFF
--- a/lib/controllers/home.js
+++ b/lib/controllers/home.js
@@ -31,6 +31,22 @@ module.exports = function (req, res, next) {
 		.then(postsDbTransformation.groupByTime)
 		.then(postsDbTransformation.setAdMarkers)
 		.then(posts => {
+			// Temporary addition until the comments are replaced
+			posts.forEach((category) => {
+				if (category && category.items) {
+					category.items.forEach((article) => {
+						const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
+						const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
+						const publishedAt = article.published_at.toISOString();
+						const commentsUseCoralTalkQuerystring = req.query.useCoralTalk;
+
+						if ((commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) || commentsUseCoralTalkQuerystring) {
+							article.useCoralTalk = true;
+						}
+					});
+				}
+			});
+
 			res.render('home', {
 				title: 'Long Room | FT Alphaville',
 				posts: posts,

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -1,11 +1,6 @@
 {{#contentFor "head"}}
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/main.css" />
 	<link rel="canonical" href="{{canonicalUrl}}" />
-{{#useCoralTalk}}
-	<script>
-		window.commentsUseCoralTalk = true;
-	</script>
-{{/useCoralTalk}}
 	<script>
 		(function () {
 			ctmLoadScript({
@@ -91,6 +86,9 @@
 			{{> alphaville-ui/share/main alphavilleUiShareData}}
 
 			{{#if useCoralTalk}}
+				<script>
+					window.commentsUseCoralTalk = true;
+				</script>
 				<a name="comments"></a>
 				<div class="o-comments"
 					id="comments"

--- a/views/partials/commentcount.handlebars
+++ b/views/partials/commentcount.handlebars
@@ -1,18 +1,12 @@
 {{#if useCoralTalk}}
+	<script>
+		window.commentsUseCoralTalk = true;
+	</script>
 	<a href="{{@root/basePath}}/content/{{id}}#comments"
 		class="o-comments alphaville-card--comment-counter"
 		data-o-component="o-comments"
-		data-o-comments-article-id="longroom{{id}}"
+		data-o-comments-article-id="{{id}}"
 		data-o-comments-count="true"
-		data-trackable="comment-count">
-	</a>
-{{else}}
-	<a href="{{@root/basePath}}/content/{{id}}#comments"
-		class="alphaville-card--comment-counter"
-		data-o-component="o-comments"
-		data-o-comments-count
-		data-o-comments-config-article-id="longroom{{id}}"
-		data-o-comments-config-template="{count}"
 		data-trackable="comment-count">
 	</a>
 {{/if}}


### PR DESCRIPTION
We're unable to render both the Coral and Livefyre comment counts
on the Alphaville Longroom stream page because `o-comments` v5 conflicts
with v6.

This PR only renders the Coral comment counts once the migration date
has passed.

Articles published before the migration date (Livefyre):
![image](https://user-images.githubusercontent.com/30316203/67416253-6c3c6700-f5be-11e9-8509-66ea8b1c35d4.png)

Articles published after the migration date (Coral):
![image](https://user-images.githubusercontent.com/30316203/67416204-56c73d00-f5be-11e9-93e7-9296bfb9fdc4.png)
