### PR TITLE
Remove comment count from Longroom article page

### DIFF
--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -25,6 +25,7 @@ module.exports = function (req, res, next) {
 					let useCoralTalk = false;
 					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
 						useCoralTalk = true;
+						post.comments.enabled = false;
 					}
 
 					const canonicalUrl = path.join(process.env.APP_URL, `/content/${post.id}`);
@@ -36,7 +37,7 @@ module.exports = function (req, res, next) {
 						canonicalUrl,
 						useCoralTalk,
 						alphavilleUiShareData: {
-							article: post.dataForShare,
+							article: post,
 							position: 'bottom'
 						}
 					});

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -25,7 +25,6 @@ module.exports = function (req, res, next) {
 					let useCoralTalk = false;
 					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
 						useCoralTalk = true;
-						post.comments.enabled = false;
 					}
 
 					const canonicalUrl = path.join(process.env.APP_URL, `/content/${post.id}`);
@@ -37,8 +36,9 @@ module.exports = function (req, res, next) {
 						canonicalUrl,
 						useCoralTalk,
 						alphavilleUiShareData: {
-							article: post,
-							position: 'bottom'
+							article: post.dataForShare,
+							position: 'bottom',
+							hideCommentCount: true
 						}
 					});
 				} else {


### PR DESCRIPTION
We had some issues with rendering the comment count on the Longroom article page. After some discussions we decided to remove it altogether because it doesn't add a lot of value to the page as the comment stream is right below it.

Before:
![image](https://user-images.githubusercontent.com/30316203/67479236-8d9c6200-f655-11e9-8f8c-71e81dbd507a.png)

After:
![image](https://user-images.githubusercontent.com/30316203/67479139-5463f200-f655-11e9-9d6f-22130269894f.png)


