### PR TITLE
Remove comment count from Longroom stream page

### DIFF
--- a/views/partials/card.handlebars
+++ b/views/partials/card.handlebars
@@ -19,7 +19,8 @@
 			</div>
 
 			<div class="alphaville-card__footer">
-				{{> commentcount}}
+				{{!-- Comment count will be reintroduced on the stream page once migration is complete --}}
+				{{!-- {{> commentcount}} --}}
 				{{> timestamp}}
 			</div>
 

--- a/views/partials/commentcount.handlebars
+++ b/views/partials/commentcount.handlebars
@@ -1,18 +1,7 @@
-{{#if useCoralTalk}}
-	<a href="{{@root/basePath}}/content/{{id}}#comments"
-		class="o-comments alphaville-card--comment-counter"
-		data-o-component="o-comments"
-		data-o-comments-article-id="longroom{{id}}"
-		data-o-comments-count="true"
-		data-trackable="comment-count">
-	</a>
-{{else}}
-	<a href="{{@root/basePath}}/content/{{id}}#comments"
-		class="alphaville-card--comment-counter"
-		data-o-component="o-comments"
-		data-o-comments-count
-		data-o-comments-config-article-id="longroom{{id}}"
-		data-o-comments-config-template="{count}"
-		data-trackable="comment-count">
-	</a>
-{{/if}}
+<a href="{{@root/basePath}}/content/{{id}}#comments"
+	class="o-comments alphaville-card--comment-counter"
+	data-o-component="o-comments"
+	data-o-comments-article-id="{{id}}"
+	data-o-comments-count="true"
+	data-trackable="comment-count">
+</a>


### PR DESCRIPTION
We're unable to render both the Coral and Livefyre comment counts
on the Longroom stream page because `o-comments` v5 conflicts with v6.

While we are in the process of migrating to Coral, we are temporarily
removing the comment count. Once migration is complete, we will render
the Coral comment count.

Before:
![image](https://user-images.githubusercontent.com/30316203/67498256-0d86f400-f677-11e9-9841-c55675c2cd1d.png)

After:
![image](https://user-images.githubusercontent.com/30316203/67498146-e0d2dc80-f676-11e9-9186-f7406f2f1ccd.png)
