### PR TITLE
Use comments-api for recent comments

### DIFF
--- a/lib/middlewares/overheardComponentData.js
+++ b/lib/middlewares/overheardComponentData.js
@@ -9,7 +9,7 @@ module.exports = function (req, res, next) {
 	if (cache.get('overheardData')) {
 		promise = Promise.resolve(cache.get('overheardData'));
 	} else {
-		promise = recentCommentsApi.get('longroom', process.env.OVERHEARD_NUMBER_OF_COMMENTS ? parseInt(process.env.OVERHEARD_NUMBER_OF_COMMENTS, 10) || 7 : 7)
+		promise = recentCommentsApi.get()
 			.then(recentComments => recentComments.map(comment => {
 				comment.bodyHtml = _.truncate(striptags(comment.bodyHtml), {length: 100, 'separator': ' '});
 				comment.commentsArticleId = comment.articleId;

--- a/lib/services/recentComments.js
+++ b/lib/services/recentComments.js
@@ -1,8 +1,6 @@
 "use strict";
 
 const fetch = require('node-fetch');
-const apiUrl = `https://${process.env.RECENT_COMMENTS_API_URL}/v1/recent-comments`;
-const defaultSiteId = process.env.COMMENTS_DEFAULT_SITE_ID;
 
 function RecentCommentsApiError(message, code, response) {
 	this.statusText = message;
@@ -17,16 +15,16 @@ function RecentCommentsApiError(message, code, response) {
 }
 RecentCommentsApiError.prototype = new Error('recentCommentsApi');
 
-exports.get = (tagName, count) => {
-	tagName = tagName || 'longroom';
-	count = count || 10;
-
-	const url = `${apiUrl}?siteid=${defaultSiteId}&tagname=${tagName}&count=${count}`;
-
-	return fetch(url).then((res) => {
+exports.get = () => {
+	return fetch(process.env.RECENT_COMMENTS_API_URL, {
+		headers: {
+			'x-api-key': process.env.COMMENTS_API_KEY
+		}
+	}).then((res) => {
 		if (!res.ok) {
 			throw new RecentCommentsApiError(res.statusText, res.status, res);
 		}
 		return res.json();
-	});
+	})
+		.then(json => json.recentComments);
 };

--- a/lib/services/recentComments.js
+++ b/lib/services/recentComments.js
@@ -16,7 +16,8 @@ function RecentCommentsApiError(message, code, response) {
 RecentCommentsApiError.prototype = new Error('recentCommentsApi');
 
 exports.get = () => {
-	return fetch(process.env.RECENT_COMMENTS_API_URL, {
+	const url = `${process.env.RECENT_COMMENTS_API_URL}?numberOfCommentsToReturn=7`;
+	return fetch(url, {
 		headers: {
 			'x-api-key': process.env.COMMENTS_API_KEY
 		}


### PR DESCRIPTION
Should only be merged after deploying this PR: https://github.com/Financial-Times/next-comments-api/pull/93

Environment variable should be updated during deployment:
`RECENT_COMMENTS_API_URL=https://comments-api.ft.com/longroom/recentcomments`