### PR TITLE
Remove Livefyre comments and count

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,12 +1,7 @@
 require('./assets');
 require('alphaville-ui');
 require('o-expander');
-// Temporary addition until the comments are replaced
-if (window.commentsUseCoralTalk) {
-	require('o-comments-beta');
-} else {
-	require('o-comments');
-}
+require('o-comments');
 require('./lib/deleteButton');
 require('./lib/permutive');
 require('./lib/ads');

--- a/bower.json
+++ b/bower.json
@@ -29,8 +29,7 @@
 		"awesomplete": "^1.1.1",
 		"o-card": "^3.0.0",
 		"tinymce": "^4.5.1",
-		"o-comments": "^5.1.1",
-		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v6.0.0-beta.52",
+		"o-comments": "^6.0.1",
 		"o-tooltip": "^3.1.2"
 	}
 }

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "Financial-Times/alphaville-ui#^2.6.0",
+		"alphaville-ui": "Financial-Times/alphaville-ui#^3.0.0",
 		"dom-delegate": "ftdomdelegate#^2.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const db = require('../services/db').db;
-const path = require('path');
 
 module.exports = function (req, res, next) {
 	if (req.params.id) {
@@ -17,16 +16,6 @@ module.exports = function (req, res, next) {
 
 				// TODO: admin access
 				if (post.published || (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor))) {
-					// Temporary addition until the comments are replaced
-					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
-					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
-					const publishedAt = post.published_at.toISOString();
-
-					let useCoralTalk = false;
-					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
-						useCoralTalk = true;
-					}
-
 					const canonicalUrl = `${process.env.APP_URL}/content/${post.id}`;
 
 					res.render('content', {
@@ -34,7 +23,6 @@ module.exports = function (req, res, next) {
 						article: post,
 						editAndDelete: (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor)) ? true : false,
 						canonicalUrl,
-						useCoralTalk,
 						alphavilleUiShareData: {
 							article: post.dataForShare,
 							position: 'bottom',

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -1,11 +1,6 @@
 {{#contentFor "head"}}
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/main.css" />
 	<link rel="canonical" href="{{canonicalUrl}}" />
-{{#useCoralTalk}}
-	<script>
-		window.commentsUseCoralTalk = true;
-	</script>
-{{/useCoralTalk}}
 	<script>
 		(function () {
 			ctmLoadScript({
@@ -90,24 +85,14 @@
 
 			{{> alphaville-ui/share/main alphavilleUiShareData}}
 
-			{{#if useCoralTalk}}
-				<a name="comments"></a>
-				<div class="o-comments"
-					id="comments"
-					data-o-component="o-comments"
-					data-o-comments-article-id="{{article.id}}"
-					data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}"
-					data-o-comments-source-app="alphaville-longroom-commentsUseCoralTalk">
-				</div>
-			{{else}}
-				<a name="comments"></a>
-				<div id="comments"
-					data-o-component="o-comments"
-					data-o-comments-config-title="{{article.title}}"
-					data-o-comments-config-url="{{article.webUrl}}"
-					data-o-comments-config-articleId="longroom{{article.id}}">
-				</div>
-			{{/if}}
+			<a name="comments"></a>
+			<div class="o-comments"
+				id="comments"
+				data-o-component="o-comments"
+				data-o-comments-article-id="{{article.id}}"
+				data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}"
+				data-o-comments-source-app="alphaville-longroom-commentsUseCoralTalk">
+			</div>
 		</div>
 	</div>
 {{/lr_layout}}

--- a/views/partials/card.handlebars
+++ b/views/partials/card.handlebars
@@ -19,8 +19,7 @@
 			</div>
 
 			<div class="alphaville-card__footer">
-				{{!-- Comment count will be reintroduced on the stream page once migration is complete --}}
-				{{!-- {{> commentcount}} --}}
+				{{> commentcount}}
 				{{> timestamp}}
 			</div>
 


### PR DESCRIPTION
This PR removes Livefyre comments and count from Alphaville Longroom. Only merge this after Coral migration is complete.

FYI, merge https://github.com/Financial-Times/alphaville-ui/pull/17 before merging this PR.