### PR TITLE
ADSDEV-277 fixes bad import of oAds causing error in console

### DIFF
--- a/assets/js/lib/ads.js
+++ b/assets/js/lib/ads.js
@@ -1,4 +1,4 @@
-import { oAds } from 'alphaville-ui';
+const oAds = require('alphaville-ui')['o-ads'];
 
 function checkInArticleAd () {
 	const inArticleAd1 = document.querySelector('.alphaville-in-article-ad1');


### PR DESCRIPTION
## Meta
* [Jira ticket ADSDEV-277](https://financialtimes.atlassian.net/browse/ADSDEV-277?atlOrigin=eyJpIjoiZDMzNDY5ODExODZjNDEwNzg0NWNmZDkxZTJlOTc5ZDgiLCJwIjoiaiJ9)
* [Similar PR on `alphaville-blogs`](https://github.com/Financial-Times/alphaville-blogs/pull/46)

## Description
`oAds` is not imported corrently into the article asset module.