### PR TITLE
Comments maintenance mode

### DIFF
--- a/assets/scss/common.scss
+++ b/assets/scss/common.scss
@@ -164,3 +164,10 @@ h2.lr-page-heading {
 	font-size: 18px;
 	min-height: 200px;
 }
+
+.comments__maintenance-mode-message {
+	@include oTypographySans(0);
+
+	margin-top: 32px;
+	margin-bottom: 32px;
+}

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -35,6 +35,7 @@ module.exports = function (req, res, next) {
 						editAndDelete: (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor)) ? true : false,
 						canonicalUrl,
 						useCoralTalk,
+						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
 						alphavilleUiShareData: {
 							article: post.dataForShare,
 							position: 'bottom',

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -90,23 +90,29 @@
 
 			{{> alphaville-ui/share/main alphavilleUiShareData}}
 
-			{{#if useCoralTalk}}
-				<a name="comments"></a>
-				<div class="o-comments"
-					id="comments"
-					data-o-component="o-comments"
-					data-o-comments-article-id="{{article.id}}"
-					data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}">
-				</div>
-			{{else}}
-				<a name="comments"></a>
-				<div id="comments"
-					data-o-component="o-comments"
-					data-o-comments-config-title="{{article.title}}"
-					data-o-comments-config-url="{{article.webUrl}}"
-					data-o-comments-config-articleId="longroom{{article.id}}">
-				</div>
-			{{/if}}
+            {{#if commentsMaintenanceMode}}
+                <div class="comments__maintenance-mode-message">
+                    There is a problem with reader comments. Our team is working on it. Please try again soon.
+                </div>
+            {{else}}
+                {{#if useCoralTalk}}
+                    <a name="comments"></a>
+                    <div class="o-comments"
+                        id="comments"
+                        data-o-component="o-comments"
+                        data-o-comments-article-id="{{article.id}}"
+                        data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}">
+                    </div>
+                {{else}}
+                    <a name="comments"></a>
+                    <div id="comments"
+                        data-o-component="o-comments"
+                        data-o-comments-config-title="{{article.title}}"
+                        data-o-comments-config-url="{{article.webUrl}}"
+                        data-o-comments-config-articleId="longroom{{article.id}}">
+                    </div>
+                {{/if}}
+            {{/if}}
 		</div>
 	</div>
 {{/lr_layout}}


### PR DESCRIPTION
When there is a technical issue with the comments, we want to display our users a friendly message instead of an error message or half loaded comments component.

When the environment variable is set `COMMENTS_MAINTENANCE_MODE=true` this message will be displayed:
<img width="807" alt="Screenshot 2019-11-20 at 16 19 52" src="https://user-images.githubusercontent.com/5130615/69261714-01c91780-0bba-11ea-8af8-f8fb74f71162.png">
