### PR TITLE
Store display name in a Longroom database

### DIFF
--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -131,6 +131,21 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 		});
 };
 
+const addPseudonymToLongroom = (user_id, formData) => {
+	const { pseudonym } = formData;
+	const encryptedPseudonym = crypto.encrypt(pseudonym);
+
+	return db.displayNames.selectById(user_id)
+		.then(user => {
+			if (!user) {
+				return db.displayName.insert(user_id, encryptedPseudonym);
+			}
+		})
+		.catch(error => {
+			throw new Error(`Error: ${error.message}`);
+		});
+};
+
 const getAccessToken = (sessionId) => {
 	const jar = request.jar();
 	const cookie = request.cookie(`${process.env['FT_SECURE_COOKIE_NAME']}=${sessionId}`);
@@ -246,6 +261,7 @@ const join = (req, res, next) => {
 			} else {
 				return Promise.join(
 					updatePseudonym(sessionId, req.body),
+					addPseudonymToLongroom(userUuid, req.body),
 					addJoinRequest(userUuid, userProfile, req.body),
 					(pseudonymResponse, joinResponse) => ({pseudonymResponse, joinResponse, userProfile})
 				);

--- a/lib/middlewares/userFromValidator.js
+++ b/lib/middlewares/userFromValidator.js
@@ -1,3 +1,4 @@
+const fetch = require('node-fetch');
 const form = require('express-form');
 const field = form.field;
 
@@ -6,6 +7,16 @@ const messages = {
 	limit(size) {
 		return `Field value can not exceed ${size} characters.`;
 	}
+};
+
+const isUnique = (displayName) => {
+	const url = `https://comments-api.ft.com/displayname/isavailable/${encodeURIComponent(displayName)}`;
+
+	return fetch(url, { method: 'GET' })
+		.then(response => response.json())
+		.then(({available}) => {
+			return available;
+		});
 };
 
 const findInvalidCharacters = (displayName) => {
@@ -32,11 +43,20 @@ const findInvalidCharacters = (displayName) => {
 		false;
 };
 
-const validation = (displayName) => {
+const validation = (displayName, source, callback) => {
 	const invalidCharacters = findInvalidCharacters(displayName);
 
 	if (invalidCharacters) {
-		throw new Error(`The display name contains the following invalid characters: ${invalidCharacters}`);
+		callback(new Error(`The display name contains the following invalid characters: ${invalidCharacters}`));
+	} else {
+		isUnique(displayName)
+				.then(isUnique => {
+					if (!isUnique) {
+						callback(new Error('Unfortunately that display name is already taken'));
+					} else {
+						callback(null);
+					}
+				});
 	}
 };
 
@@ -44,7 +64,7 @@ module.exports = () => {
 	return form(
 		field('pseudonym').trim()
 			.required('', messages.required)
-			.custom(displayName => validation(displayName)),
+			.custom(validation),
 		field('location').trim()
 			.required('', messages.required)
 			.maxLength(100, messages.limit(100))

--- a/lib/middlewares/userFromValidator.js
+++ b/lib/middlewares/userFromValidator.js
@@ -46,7 +46,9 @@ const findInvalidCharacters = (displayName) => {
 const validation = (displayName, source, callback) => {
 	const invalidCharacters = findInvalidCharacters(displayName);
 
-	if (invalidCharacters) {
+	if (source.pseudonym) {
+		callback(null);
+	} else if (invalidCharacters) {
 		callback(new Error(`The display name contains the following invalid characters: ${invalidCharacters}`));
 	} else {
 		isUnique(displayName)

--- a/lib/middlewares/userFromValidator.js
+++ b/lib/middlewares/userFromValidator.js
@@ -1,8 +1,6 @@
 const form = require('express-form');
 const field = form.field;
 
-const textRegexp = /^[a-zA-Z0-9,.!-;&? ]*$/;
-
 const messages = {
 	required: 'Field is required',
 	limit(size) {
@@ -10,10 +8,43 @@ const messages = {
 	}
 };
 
+const findInvalidCharacters = (displayName) => {
+	/*
+	 * Allowed Characters
+	 * The below regex matches any character not in the allowed characters set
+	 * All allowed characters are case insensitive
+	 * Anything in the range A-Z or 0-9 is allowed
+	 * Any of the below special characters are allowed
+	 * !#$%'`()*+,-./:;=@[]^_{|}
+	 * Spaces are allowed
+	 */
+
+	const matchInvalidCharacters = /[^0-9a-z!#$%'`()*+,\-.\/:;=@[\]\^_{}\|\s]/gi;
+	const matchingCharacters = displayName
+		.match(matchInvalidCharacters);
+	const uniqueMatchingCharacters = matchingCharacters && matchingCharacters.length ?
+		matchingCharacters
+			.filter((character, position) => matchingCharacters.indexOf(character) === position) :
+		[];
+
+	return uniqueMatchingCharacters.length ?
+		uniqueMatchingCharacters.join('') :
+		false;
+};
+
+const validation = (displayName) => {
+	const invalidCharacters = findInvalidCharacters(displayName);
+
+	if (invalidCharacters) {
+		throw new Error(`The display name contains the following invalid characters: ${invalidCharacters}`);
+	}
+};
+
 module.exports = () => {
 	return form(
 		field('pseudonym').trim()
-			.required('', messages.required),
+			.required('', messages.required)
+			.custom(displayName => validation(displayName)),
 		field('location').trim()
 			.required('', messages.required)
 			.maxLength(100, messages.limit(100))

--- a/lib/repos/displayNames.js
+++ b/lib/repos/displayNames.js
@@ -1,0 +1,10 @@
+const sql = require('../sql').displayNames;
+
+module.exports = (rep) => {
+	return {
+		insert: (user_id, display_name) => rep.one(sql.insert, {user_id, display_name}),
+		updateDisplayName: (display_name) => rep.one(sql.updateDisplayName, {user_id, display_name}),
+		deleteByUserId: (user_id) => rep.none(sql.deleteByUserId, {user_id}),
+		selectById: (user_id) => rep.any(sql.selectByUserId, {user_id})
+	};
+};

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -7,7 +7,8 @@ const repos = {
 	post: require('../repos/post'),
 	tag: require('../repos/tag'),
 	tagToPost: require('../repos/tagToPost'),
-	cleanupStatus: require('../repos/cleanupStatus')
+	cleanupStatus: require('../repos/cleanupStatus'),
+	displayNames: require('../repos/displayNames')
 };
 
 const options = {

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -20,6 +20,7 @@ const options = {
 		obj.tag = repos.tag(obj, pgp);
 		obj.tagToPost = repos.tagToPost(obj, pgp);
 		obj.cleanupStatus = repos.cleanupStatus(obj, pgp);
+		obj.displayNames = repos.displayNames(obj, pgp);
 
 		const origTxFn = obj.tx;
 

--- a/lib/sql/displayNames/deleteByUserId.sql
+++ b/lib/sql/displayNames/deleteByUserId.sql
@@ -1,0 +1,2 @@
+DELETE FROM display_names
+WHERE user_id = ${user_id}

--- a/lib/sql/displayNames/insert.sql
+++ b/lib/sql/displayNames/insert.sql
@@ -1,0 +1,7 @@
+INSERT INTO display_names (
+    user_id,
+    display_name
+) VALUES (
+    ${user_id},
+    ${display_name}
+)

--- a/lib/sql/displayNames/selectByUserId.sql
+++ b/lib/sql/displayNames/selectByUserId.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM display_names
+WHERE user_id = ${user_id}

--- a/lib/sql/displayNames/updateDisplayName.sql
+++ b/lib/sql/displayNames/updateDisplayName.sql
@@ -1,0 +1,5 @@
+UPDATE display_names SET
+	display_name = ${display_name}
+WHERE
+	user_id = ${user_id}
+

--- a/lib/sql/index.js
+++ b/lib/sql/index.js
@@ -64,5 +64,11 @@ module.exports = {
 	cleanupStatus: {
 		update: sql('cleanupStatus/update.sql'),
 		get: sql('cleanupStatus/get.sql')
+	},
+	displayNames: {
+		insert: sql('displayNames/insert.sql'),
+		updateDisplayName: sql('displayNames/updateDisplayName.sql'),
+		deleteByUserId: sql('displayNames/deleteByUserId.sql'),
+		selectByUserId: sql('displayNames/selectByUserId.sql')
 	}
 };

--- a/views/joinForm.handlebars
+++ b/views/joinForm.handlebars
@@ -57,7 +57,9 @@
 					<label class="o-forms-field" for="pseudonym">
 						<span class="o-forms-title">
 							<span class="o-forms-title__main">Display name *</span>
-							<span class="o-forms-title__prompt">This will also be used for comments and posts</span>
+							<span class="o-forms-title__prompt">
+								This will be used for comments and posts. If you change your display name on FT.com or the app, it will be reflected in Longroom.
+							</span>
 						</span>
 
 						<span class="o-forms-input o-forms-input--text o-forms-input--invalid">
@@ -73,11 +75,18 @@
 					<label class="o-forms-field" for="pseudonym">
 						<span class="o-forms-title">
 							<span class="o-forms-title__main">Display name *</span>
-							<span class="o-forms-title__prompt">This will also be used for comments and posts</span>
+							<span class="o-forms-title__prompt">
+								This will be used for comments and posts. If you change your display name on FT.com or the app, it will be reflected in Longroom.
+							</span>
 						</span>
 
 						<span class="o-forms-input o-forms-input--text">
-							<input required type="text" name="pseudonym" value="{{pseudonym}}" />
+							{{#if pseudonym}}
+								<input type="text" name="pseudonym" value="{{pseudonym}}" disabled />
+								<input type="hidden" name="pseudonym" value="{{pseudonym}}" />
+							{{else}}
+								<input required type="text" name="pseudonym" value="{{pseudonym}}" />
+							{{/if}}
 						</span>
 					</label>
 				</div>


### PR DESCRIPTION
If a user has a commenting display name, it is pre-populated in the display name input. Previously, a user could update their display name in the form but we're removing this ability by disabling the input. We're doing this because we're unable to easily create a user using Coral's API.

If a user doesn't have a commenting display name, they will be asked to create one when they sign up for Longroom. This display name will then be saved in the Longroom database.

This is part of some work being completed to keep Longroom in sync with FT.com. 

**When a user already has a commenting display name:**

![image](https://user-images.githubusercontent.com/30316203/70798639-66355c00-1d9f-11ea-8eb3-9495504e1d45.png)

**When a user enters a display name with in invalid characters:**

![image](https://user-images.githubusercontent.com/30316203/70799050-7f8ad800-1da0-11ea-83de-098c13d097f3.png)

**When a user enters a display name that already exists:**

![image](https://user-images.githubusercontent.com/30316203/70799287-1fe0fc80-1da1-11ea-95a2-b0bf1182e9f4.png)
