### PR TITLE
Allow commenting display names to be kept up to date

### DIFF
--- a/lib/controllers/api.js
+++ b/lib/controllers/api.js
@@ -1,6 +1,7 @@
 const db = require('../services/db').db;
 const als = require('../services/als');
 const s3 = require('../services/s3');
+const crypto = require('../services/crypto');
 
 
 const removeUser = user_id => {
@@ -69,6 +70,13 @@ const removeAllContent = user_id => {
 };
 
 
+const displayNameExists = uuid => {
+	return db.displayNames.selectById(uuid)
+		.then((users) => {
+			return users.length ? true : false;
+		});
+};
+
 exports.deleteUser = (req, res, next) => {
 	let { user_id } = req.query;
 	console.log('processing ID', user_id);
@@ -94,4 +102,24 @@ exports.deleteUser = (req, res, next) => {
 			reason: err
 		});
 	});
+};
+
+exports.syncDisplayName = async (req, res, next) => {
+	const { uuid } = req.params;
+	const { displayName } = req.body;
+	const userExitsInDisplayNameTable = await displayNameExists(uuid);
+
+	if (userExitsInDisplayNameTable) {
+		const encryptedDisplayName = crypto.encrypt(displayName)
+		db.displayNames.updateDisplayName(uuid, encryptedDisplayName)
+			.then((user) => {
+				return res.sendStatus(200);
+			})
+			.catch(error => {
+				console.log(error);
+				return res.status(500);
+			});
+	} else {
+		return res.sendStatus(404);
+	}
 };

--- a/lib/repos/displayNames.js
+++ b/lib/repos/displayNames.js
@@ -3,7 +3,7 @@ const sql = require('../sql').displayNames;
 module.exports = (rep) => {
 	return {
 		insert: (user_id, display_name) => rep.one(sql.insert, {user_id, display_name}),
-		updateDisplayName: (display_name) => rep.one(sql.updateDisplayName, {user_id, display_name}),
+		updateDisplayName: (user_id, display_name) => rep.one(sql.updateDisplayName, {user_id, display_name}),
 		deleteByUserId: (user_id) => rep.none(sql.deleteByUserId, {user_id}),
 		selectById: (user_id) => rep.any(sql.selectByUserId, {user_id})
 	};

--- a/lib/repos/displayNames.js
+++ b/lib/repos/displayNames.js
@@ -1,0 +1,10 @@
+const sql = require('../sql').displayNames;
+
+module.exports = (rep) => {
+	return {
+		insert: (user_id, display_name) => rep.one(sql.insert, {user_id, display_name}),
+		updateDisplayName: (display_name) => rep.one(sql.updateDisplayName, {user_id, display_name}),
+		deleteByUserId: (user_id) => rep.none(sql.deleteByUserId, {user_id}),
+		selectById: (user_id) => rep.any(sql.selectByUserId, {user_id})
+	};
+};

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -7,7 +7,8 @@ const repos = {
 	post: require('../repos/post'),
 	tag: require('../repos/tag'),
 	tagToPost: require('../repos/tagToPost'),
-	cleanupStatus: require('../repos/cleanupStatus')
+	cleanupStatus: require('../repos/cleanupStatus'),
+	displayNames: require('../repos/displayNames')
 };
 
 const options = {

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -20,6 +20,7 @@ const options = {
 		obj.tag = repos.tag(obj, pgp);
 		obj.tagToPost = repos.tagToPost(obj, pgp);
 		obj.cleanupStatus = repos.cleanupStatus(obj, pgp);
+		obj.displayNames = repos.displayNames(obj, pgp);
 
 		const origTxFn = obj.tx;
 

--- a/lib/sql/displayNames/deleteByUserId.sql
+++ b/lib/sql/displayNames/deleteByUserId.sql
@@ -1,0 +1,2 @@
+DELETE FROM display_names
+WHERE user_id = ${user_id}

--- a/lib/sql/displayNames/insert.sql
+++ b/lib/sql/displayNames/insert.sql
@@ -1,0 +1,7 @@
+INSERT INTO display_names (
+    user_id,
+    display_name
+) VALUES (
+    ${user_id},
+    ${display_name}
+)

--- a/lib/sql/displayNames/selectByUserId.sql
+++ b/lib/sql/displayNames/selectByUserId.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM display_names
+WHERE user_id = ${user_id}

--- a/lib/sql/displayNames/updateDisplayName.sql
+++ b/lib/sql/displayNames/updateDisplayName.sql
@@ -1,5 +1,4 @@
-UPDATE display_names SET
-	display_name = ${display_name}
-WHERE
-	user_id = ${user_id}
-
+UPDATE display_names
+SET display_name = ${display_name}
+WHERE user_id = ${user_id}
+RETURNING user_id, display_name

--- a/lib/sql/displayNames/updateDisplayName.sql
+++ b/lib/sql/displayNames/updateDisplayName.sql
@@ -1,0 +1,5 @@
+UPDATE display_names SET
+	display_name = ${display_name}
+WHERE
+	user_id = ${user_id}
+

--- a/lib/sql/index.js
+++ b/lib/sql/index.js
@@ -64,5 +64,11 @@ module.exports = {
 	cleanupStatus: {
 		update: sql('cleanupStatus/update.sql'),
 		get: sql('cleanupStatus/get.sql')
+	},
+	displayNames: {
+		insert: sql('displayNames/insert.sql'),
+		updateDisplayName: sql('displayNames/updateDisplayName.sql'),
+		deleteByUserId: sql('displayNames/deleteByUserId.sql'),
+		selectByUserId: sql('displayNames/selectByUserId.sql')
 	}
 };

--- a/routes/apiRouter.js
+++ b/routes/apiRouter.js
@@ -2,5 +2,6 @@ const router = require('express').Router();
 const apiCtrl = require('../lib/controllers/api');
 
 router.get('/delete-user', apiCtrl.deleteUser);
+router.put('/sync-displayname/:uuid', apiCtrl.syncDisplayName);
 
 module.exports = router;

--- a/schema.sql
+++ b/schema.sql
@@ -66,11 +66,19 @@ CREATE TABLE IF NOT EXISTS user_details (
     responsibility character varying(256)
 );
 
+CREATE TABLE IF NOT EXISTS display_names (
+    user_id uuid NOT NULL,
+    display_name character varying(256)
+);
+
 ALTER TABLE ONLY user_details
     ADD CONSTRAINT user_details_pkey PRIMARY KEY (user_id);
 
 ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (user_id);
+
+ALTER TABLE ONLY display_names
+    ADD CONSTRAINT display_names_pkey PRIMARY KEY (user_id);
 
 ALTER TABLE ONLY user_details
     ADD CONSTRAINT user_details_id FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE;


### PR DESCRIPTION
This creates a new endpoint that will allow display name changes to be synced with
Longroom.


**Why**
This will happen if the user signs up for Longroom and doesn't already
have a display name so creates it during the sign up process. If they
then go away and create a commenting account on an article page and choose a different
display name it will sync across to Longroom and any subsequent updates.

The display name will only be stored for a temporary period until the user is accepted or rejected
from Longroom.

If they are accepted the display name will be removed
from the longroom database once the visit a longroom post and a
commenting account is created for them. - This will be built in a separate PR

If they are rejected from Longroom the display name row will be removed
straight away. - This will be built in a separate PR

This helps us manage the delay / race condition of users requesting
access to Longroom and being accepted.