### PR TITLE
Store newly created display names in Longroom

### DIFF
--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -131,6 +131,21 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 		});
 };
 
+const addPseudonymToLongroom = (user_id, formData) => {
+	const { pseudonym } = formData;
+	const encryptedPseudonym = crypto.encrypt(pseudonym);
+
+	return db.displayNames.selectById(user_id)
+		.then(user => {
+			if (!user) {
+				return db.displayName.insert(user_id, encryptedPseudonym);
+			}
+		})
+		.catch(error => {
+			throw new Error(`Error: ${error.message}`);
+		});
+};
+
 const getAccessToken = (sessionId) => {
 	const jar = request.jar();
 	const cookie = request.cookie(`${process.env['FT_SECURE_COOKIE_NAME']}=${sessionId}`);
@@ -246,6 +261,7 @@ const join = (req, res, next) => {
 			} else {
 				return Promise.join(
 					updatePseudonym(sessionId, req.body),
+					addPseudonymToLongroom(userUuid, req.body),
 					addJoinRequest(userUuid, userProfile, req.body),
 					(pseudonymResponse, joinResponse) => ({pseudonymResponse, joinResponse, userProfile})
 				);

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -133,6 +133,13 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 
 const addPseudonymToLongroom = (user_id, formData) => {
 	const { pseudonym } = formData;
+
+	if (!pseudonym) {
+		// pseudonym should only not exist if the user already has a commenting pseudonym so we don't need to save it
+		// If the user just didn't enter one it should get stopped by the userFromValidator middleware
+		return;
+	}
+
 	const encryptedPseudonym = crypto.encrypt(pseudonym);
 
 	return db.displayNames.selectById(user_id)

--- a/lib/middlewares/userFromValidator.js
+++ b/lib/middlewares/userFromValidator.js
@@ -1,3 +1,4 @@
+const fetch = require('node-fetch');
 const form = require('express-form');
 const field = form.field;
 
@@ -6,6 +7,16 @@ const messages = {
 	limit(size) {
 		return `Field value can not exceed ${size} characters.`;
 	}
+};
+
+const isUnique = (displayName) => {
+	const url = `https://comments-api.ft.com/displayname/isavailable/${encodeURIComponent(displayName)}`;
+
+	return fetch(url, { method: 'GET' })
+		.then(response => response.json())
+		.then(({available}) => {
+			return available;
+		});
 };
 
 const findInvalidCharacters = (displayName) => {
@@ -32,11 +43,20 @@ const findInvalidCharacters = (displayName) => {
 		false;
 };
 
-const validation = (displayName) => {
+const validation = (displayName, source, callback) => {
 	const invalidCharacters = findInvalidCharacters(displayName);
 
 	if (invalidCharacters) {
-		throw new Error(`The display name contains the following invalid characters: ${invalidCharacters}`);
+		callback(new Error(`The display name contains the following invalid characters: ${invalidCharacters}`));
+	} else {
+		isUnique(displayName)
+				.then(isUnique => {
+					if (!isUnique) {
+						callback(new Error('Unfortunately that display name is already taken'));
+					} else {
+						callback(null);
+					}
+				});
 	}
 };
 
@@ -44,7 +64,7 @@ module.exports = () => {
 	return form(
 		field('pseudonym').trim()
 			.required('', messages.required)
-			.custom(displayName => validation(displayName)),
+			.custom(validation),
 		field('location').trim()
 			.required('', messages.required)
 			.maxLength(100, messages.limit(100))

--- a/lib/middlewares/userFromValidator.js
+++ b/lib/middlewares/userFromValidator.js
@@ -1,8 +1,6 @@
 const form = require('express-form');
 const field = form.field;
 
-const textRegexp = /^[a-zA-Z0-9,.!-;&? ]*$/;
-
 const messages = {
 	required: 'Field is required',
 	limit(size) {
@@ -10,10 +8,43 @@ const messages = {
 	}
 };
 
+const findInvalidCharacters = (displayName) => {
+	/*
+	 * Allowed Characters
+	 * The below regex matches any character not in the allowed characters set
+	 * All allowed characters are case insensitive
+	 * Anything in the range A-Z or 0-9 is allowed
+	 * Any of the below special characters are allowed
+	 * !#$%'`()*+,-./:;=@[]^_{|}
+	 * Spaces are allowed
+	 */
+
+	const matchInvalidCharacters = /[^0-9a-z!#$%'`()*+,\-.\/:;=@[\]\^_{}\|\s]/gi;
+	const matchingCharacters = displayName
+		.match(matchInvalidCharacters);
+	const uniqueMatchingCharacters = matchingCharacters && matchingCharacters.length ?
+		matchingCharacters
+			.filter((character, position) => matchingCharacters.indexOf(character) === position) :
+		[];
+
+	return uniqueMatchingCharacters.length ?
+		uniqueMatchingCharacters.join('') :
+		false;
+};
+
+const validation = (displayName) => {
+	const invalidCharacters = findInvalidCharacters(displayName);
+
+	if (invalidCharacters) {
+		throw new Error(`The display name contains the following invalid characters: ${invalidCharacters}`);
+	}
+};
+
 module.exports = () => {
 	return form(
 		field('pseudonym').trim()
-			.required('', messages.required),
+			.required('', messages.required)
+			.custom(displayName => validation(displayName)),
 		field('location').trim()
 			.required('', messages.required)
 			.maxLength(100, messages.limit(100))

--- a/lib/middlewares/userFromValidator.js
+++ b/lib/middlewares/userFromValidator.js
@@ -46,7 +46,14 @@ const findInvalidCharacters = (displayName) => {
 const validation = (displayName, source, callback) => {
 	const invalidCharacters = findInvalidCharacters(displayName);
 
-	if (invalidCharacters) {
+	if (typeof source.pseudonym === 'undefined') {
+		// The users psedudonym was prepopulated as they already have a commenting account
+		// In this case we don't pass the psedudonym in the form so no need to validate
+		callback(null);
+	} else if (!source.pseudonym.length) {
+		// User has left the psedudonym field blank and it is required
+		callback(new Error(messages.required));
+	} else if (invalidCharacters) {
 		callback(new Error(`The display name contains the following invalid characters: ${invalidCharacters}`));
 	} else {
 		isUnique(displayName)
@@ -63,7 +70,6 @@ const validation = (displayName, source, callback) => {
 module.exports = () => {
 	return form(
 		field('pseudonym').trim()
-			.required('', messages.required)
 			.custom(validation),
 		field('location').trim()
 			.required('', messages.required)

--- a/views/joinForm.handlebars
+++ b/views/joinForm.handlebars
@@ -83,7 +83,6 @@
 						<span class="o-forms-input o-forms-input--text">
 							{{#if pseudonym}}
 								<input type="text" name="pseudonym" value="{{pseudonym}}" disabled />
-								<input type="hidden" name="pseudonym" value="{{pseudonym}}" />
 							{{else}}
 								<input required type="text" name="pseudonym" value="{{pseudonym}}" />
 							{{/if}}

--- a/views/joinForm.handlebars
+++ b/views/joinForm.handlebars
@@ -57,7 +57,9 @@
 					<label class="o-forms-field" for="pseudonym">
 						<span class="o-forms-title">
 							<span class="o-forms-title__main">Display name *</span>
-							<span class="o-forms-title__prompt">This will also be used for comments and posts</span>
+							<span class="o-forms-title__prompt">
+								This will be used for comments and posts. If you change your display name on FT.com or the app, it will be reflected in Longroom.
+							</span>
 						</span>
 
 						<span class="o-forms-input o-forms-input--text o-forms-input--invalid">
@@ -73,11 +75,18 @@
 					<label class="o-forms-field" for="pseudonym">
 						<span class="o-forms-title">
 							<span class="o-forms-title__main">Display name *</span>
-							<span class="o-forms-title__prompt">This will also be used for comments and posts</span>
+							<span class="o-forms-title__prompt">
+								This will be used for comments and posts. If you change your display name on FT.com or the app, it will be reflected in Longroom.
+							</span>
 						</span>
 
 						<span class="o-forms-input o-forms-input--text">
-							<input required type="text" name="pseudonym" value="{{pseudonym}}" />
+							{{#if pseudonym}}
+								<input type="text" name="pseudonym" value="{{pseudonym}}" disabled />
+								<input type="hidden" name="pseudonym" value="{{pseudonym}}" />
+							{{else}}
+								<input required type="text" name="pseudonym" value="{{pseudonym}}" />
+							{{/if}}
 						</span>
 					</label>
 				</div>


### PR DESCRIPTION
When a user registers with Longroom who previously didn't have a commenting account with an associated display name store it in the Longroom database.

This will then allow us to create their account once they have been accepted into Longroom