### PR TITLE
Remove the display name when users are rejected

### DIFF
--- a/lib/controllers/admin.js
+++ b/lib/controllers/admin.js
@@ -30,6 +30,7 @@ const approveUser = user_id => {
 const rejectUser = user_id => {
 	return db.user.updateUserStatus(user_id, 'rejected')
 		.then(db.userDetails.deleteById(user_id))
+		.then(db.displayNames.deleteByUserId(user_id))
 		.then(() => mailer.sendRejected(user_id));
 };
 


### PR DESCRIPTION
We don't need to keep hold of the display name after the user has been
rejected from Longroom.