### PR TITLE
Only throw Comments API error in certain cases

### DIFF
--- a/lib/services/commentsApi.js
+++ b/lib/services/commentsApi.js
@@ -24,7 +24,7 @@ exports.getUser = (userId, doNotThrowError) => {
 
 	return fetch(url, options).then((res) => {
 		if (!res.ok && !(res.status === 404) && doNotThrowError) {
-			return {};
+			return {userId};
 		}
 
 		if (!res.ok && !(res.status === 404)) {

--- a/lib/services/commentsApi.js
+++ b/lib/services/commentsApi.js
@@ -13,7 +13,7 @@ function CommentsApiError(message, code, response) {
 }
 CommentsApiError.prototype = new Error('commentsApi');
 
-exports.getUser = userId => {
+exports.getUser = (userId, doNotThrowError) => {
 	const options = {
 		headers: {
 			'X-Api-Key': process.env.COMMENTS_API_KEY
@@ -23,6 +23,10 @@ exports.getUser = userId => {
 	const url = `${process.env.COMMENTS_API_URL}/user/${userId}`;
 
 	return fetch(url, options).then((res) => {
+		if (!res.ok && !(res.status === 404) && doNotThrowError) {
+			return {};
+		}
+
 		if (!res.ok && !(res.status === 404)) {
 			throw new CommentsApiError(res.statusText, res.status, res);
 		}
@@ -31,7 +35,7 @@ exports.getUser = userId => {
 };
 
 exports.getMultipleUsers = userIds => {
-	const promises = userIds.map(id => exports.getUser(id));
+	const promises = userIds.map(id => exports.getUser(id, true));
 
 	return Promise.all(promises)
 		.then(responses => {


### PR DESCRIPTION
When an author is no longer a Longroom member, we do not want to throw
an error because we still want the article to be visible.