### PR TITLE
Remove the old version of o-comments

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,11 +1,6 @@
 require('./assets');
 require('alphaville-ui');
-// Temporary addition until the comments are replaced
-if (window.commentsUseCoralTalk) {
-	require('o-comments-beta');
-} else {
-	require('o-comments');
-}
+require('o-comments');
 require('./lib/deleteButton');
 require('./lib/permutive');
 require('./lib/ads');

--- a/assets/scss/common.scss
+++ b/assets/scss/common.scss
@@ -2,11 +2,10 @@
 
 @import 'alphaville-ui/main';
 @import './create_form';
-@import 'o-comments/main';
 @import 'o-normalise/main';
 
 $o-comments-is-silent: false;
-@import 'o-comments-beta/main';
+@import 'o-comments/main';
 
 @include oNormalise();
 

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,6 @@
 		"awesomplete": "^1.1.1",
 		"o-normalise": "^2.0.0",
 		"tinymce": "^4.5.1",
-		"o-comments": "https://github.com/Financial-Times/o-comments.git#major-cascade-breaking-v5",
-		"o-comments-beta": "https://github.com/Financial-Times/o-comments.git#v7.1.4"
+		"o-comments": "^v7.1.4"
 	}
 }

--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -27,11 +27,6 @@ module.exports = function (req, res, next) {
 						useCoralTalk = true;
 					}
 
-					// Temporary addition until comments migration is complete
-					const now = new Date().getTime();
-					const startOf2020 = 1577836800000; // 2020-01-01T00:00:00.000Z
-					const commentsMigrationMessage = now >= startOf2020;
-
 					const canonicalUrl = `${process.env.APP_URL}/content/${post.id}`;
 
 					res.render('content', {
@@ -41,7 +36,6 @@ module.exports = function (req, res, next) {
 						canonicalUrl,
 						useCoralTalk,
 						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
-						commentsMigrationMessage,
 						alphavilleUiShareData: {
 							article: post.dataForShare,
 							position: 'bottom',

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -1,11 +1,7 @@
 {{#contentFor "head"}}
 	<link rel="stylesheet" href="{{assetsBasePath}}/build/main.css" />
 	<link rel="canonical" href="{{canonicalUrl}}" />
-{{#useCoralTalk}}
-	<script>
-		window.commentsUseCoralTalk = true;
-	</script>
-{{/useCoralTalk}}
+
 	<script>
 		(function () {
 			ctmLoadScript({
@@ -104,20 +100,10 @@
                         data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}">
                     </div>
                 {{else}}
-                    {{#if commentsMigrationMessage}}
-                        <div class="comments__maintenance-mode-message">
-                            <p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
-                            <p>Note that this only affects articles published before 28th October 2019.</p>
-                        </div>
-                    {{else}}
-                        <a name="comments"></a>
-                        <div id="comments"
-                            data-o-component="o-comments"
-                            data-o-comments-config-title="{{article.title}}"
-                            data-o-comments-config-url="{{article.webUrl}}"
-                            data-o-comments-config-articleId="longroom{{article.id}}">
-                        </div>
-                    {{/if}}
+					<div class="comments__maintenance-mode-message">
+						<p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
+						<p>Note that this only affects articles published before 28th October 2019.</p>
+					</div>
                 {{/if}}
             {{/if}}
 		</div>


### PR DESCRIPTION
The old version was used to load livefyre comments, as we are no longer
loading comments from livefyre we can promote the -beta version to be
the stable version used.