### PR TITLE
Upgrade to node 8.17.0 and increase max header limit

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: npm start
-worker: node ./bin/worker
+worker: node --max-http-header-size=80000 ./bin/worker

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "engines": {
-    "node": "^8"
+    "node": "8.17.0"
   },
   "dependencies": {
     "@financial-times/express-web-service": "^3.3.1",


### PR DESCRIPTION
[JIRA Ticket](https://financialtimes.atlassian.net/jira/software/projects/NOPSCOPS/boards/952?selectedIssue=NOPSCOPS-203)

The application seems to sometimes be breaking when too many cookies are sent so @sjparkinson pointed out that it seems like an issue we had a while back where this was the solution.