### PR TITLE
ADSDEV-449 Use n-permutive for Alphaville

### DIFF
--- a/assets/js/lib/permutive.js
+++ b/assets/js/lib/permutive.js
@@ -1,6 +1,22 @@
-const contentId = document.documentElement.dataset.contentId;
-const Permutive = require('alphaville-ui')['permutive'];
+const nPermutive = require('n-permutive');
 
-Permutive.initPermutive();
-Permutive.setUserAndContent(contentId);
-Permutive.setPermutiveSegments();
+const PERMUTIVE_CREDENTIALS = {
+	publicId: 'e1c3fd73-dd41-4abd-b80b-4278d52bf7aa',
+	publicApikey: 'b2b3b748-e1f6-4bd5-b2f2-26debc8075a3',
+}
+
+const getAppName = targeting => targeting && targeting.auuid
+	? 'article'
+	: 'homepage';
+
+nPermutive.setup(PERMUTIVE_CREDENTIALS);
+nPermutive.loadPermutiveScript(PERMUTIVE_CREDENTIALS.publicId);
+
+// Wait for oAds to complete initialisation, in order to access the targeting meta
+// and Then identify the user and track PageView
+oAds.utils.on('initialised', () => {
+	const targeting = oAds.targeting.get();
+
+	nPermutive.identifyUser(targeting);
+	nPermutive.trackPageView(targeting, getAppName(targeting), oAds.config('behavioralMeta'));
+})

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "^4.0.0",
+		"alphaville-ui": "^5.0.0",
 		"ftdomdelegate": "^4.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "multer": "^1.3.0",
-    "n-permutive": "^2.3.0",
+    "n-permutive": "^2.3.2",
     "node-fetch": "^1.5.2",
     "pg-promise": "^5.4.3",
     "request": "^2.74.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "multer": "^1.3.0",
+    "n-permutive": "^2.3.0",
     "node-fetch": "^1.5.2",
     "pg-promise": "^5.4.3",
     "request": "^2.74.0",


### PR DESCRIPTION
## Meta
Part of Jira [ADSDEV-449 Use n-permutive for alphaville][ADSDEV-449]
See similar PR for `alphaville-blogs` https://github.com/Financial-Times/alphaville-blogs/pull/69

## Description
We are now using directly `n-permutive`, instead of the helper module `permutive` exported via alphaville-ui, which was a wrapper around `o-permutive`.

It awaits for oAds's `initialised` event to be thrown, in order to access the targeting exposed by oAds and then identifying the user and track the PageView

## Release notes
Depends on `alphaville@5.x`, which includes this changes https://github.com/Financial-Times/alphaville-ui/pull/27

[ADSDEV-449]: https://financialtimes.atlassian.net/browse/ADSDEV-449