### PR TITLE
Remove comments migration message

### DIFF
--- a/lib/controllers/view.js
+++ b/lib/controllers/view.js
@@ -17,16 +17,6 @@ module.exports = function (req, res, next) {
 
 				// TODO: admin access
 				if (post.published || (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor))) {
-					// Temporary addition until the comments are replaced
-					const commentsUseCoralMilestoneDate = process.env.COMMENTS_USE_CORAL_MILESTONE_DATE;
-					const commentsUseCoralTalk = process.env.COMMENTS_USE_CORAL_TALK === 'true';
-					const publishedAt = post.published_at.toISOString();
-
-					let useCoralTalk = false;
-					if (commentsUseCoralMilestoneDate && commentsUseCoralTalk && publishedAt > commentsUseCoralMilestoneDate) {
-						useCoralTalk = true;
-					}
-
 					const canonicalUrl = `${process.env.APP_URL}/content/${post.id}`;
 
 					res.render('content', {
@@ -34,7 +24,6 @@ module.exports = function (req, res, next) {
 						article: post,
 						editAndDelete: (req.userData && (req.userData.user_id === post.user_id || req.userData.is_editor)) ? true : false,
 						canonicalUrl,
-						useCoralTalk,
 						commentsMaintenanceMode: process.env.COMMENTS_MAINTENANCE_MODE === 'true',
 						alphavilleUiShareData: {
 							article: post.dataForShare,

--- a/views/content.handlebars
+++ b/views/content.handlebars
@@ -91,24 +91,17 @@
                     There is a problem with reader comments. Our team is working on it. Please try again soon.
                 </div>
             {{else}}
-                {{#if useCoralTalk}}
-                    <a name="comments"></a>
-                    <div class="o-comments"
-                        id="comments"
-                        data-o-component="o-comments"
-                        data-o-comments-article-id="{{article.id}}"
-                        data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}"
-                        {{#if temporaryCommentsPseudonym}}
-                         data-o-comments-display-name="{{temporaryCommentsPseudonym}}"
-                        {{/if}}
-                    >
-                    </div>
-                {{else}}
-					<div class="comments__maintenance-mode-message">
-						<p>Commenting on this article is temporarily unavailable while we migrate to our new comments system.</p>
-						<p>Note that this only affects articles published before 28th October 2019.</p>
-					</div>
-                {{/if}}
+                <a name="comments"></a>
+                <div class="o-comments"
+                    id="comments"
+                    data-o-component="o-comments"
+                    data-o-comments-article-id="{{article.id}}"
+                    data-o-comments-article-url="https://ftalphaville.ft.com/longroom/content/{{article.id}}"
+                    {{#if temporaryCommentsPseudonym}}
+                     data-o-comments-display-name="{{temporaryCommentsPseudonym}}"
+                    {{/if}}
+                >
+                </div>
             {{/if}}
 		</div>
 	</div>


### PR DESCRIPTION
Since the comments data migration from Livefyre to Coral is complete, we can remove the migration message and cleanup the related logic.