### PR TITLE
ADSDEV-407 Update dependency n-permutive@2.4.0

### DIFF
--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,6 +1,6 @@
+require('./lib/permutive');
 require('./assets');
 require('alphaville-ui');
 require('o-comments');
 require('./lib/deleteButton');
-require('./lib/permutive');
 require('./lib/ads');

--- a/assets/js/lib/permutive.js
+++ b/assets/js/lib/permutive.js
@@ -14,7 +14,7 @@ nPermutive.loadPermutiveScript(PERMUTIVE_CREDENTIALS.publicId);
 
 // Wait for oAds to complete initialisation, in order to access the targeting meta
 // and Then identify the user and track PageView
-oAds.utils.on('initialised', () => {
+document.body.addEventListener('oAds.initialised', () => {
 	const targeting = oAds.targeting.get();
 
 	nPermutive.identifyUser(targeting);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "memory-cache": "^0.1.6",
     "moment-timezone": "^0.5.5",
     "multer": "^1.3.0",
-    "n-permutive": "^2.3.2",
+    "n-permutive": "^2.4.0",
     "node-fetch": "^1.5.2",
     "pg-promise": "^5.4.3",
     "request": "^2.74.0",


### PR DESCRIPTION
## Meta
[ADSDEV-407][ADSDEV-407]
See similar changes in **alphaville-blogs** https://github.com/Financial-Times/alphaville-blogs/pull/72

## Description
Use the latest `n-permutive@2.4.0`, which adds permutive's `view-id` to ads targeting.
Also listen to event `oAds.initialised` before running any code that relies on oAds.

[ADSDEV-407]: https://financialtimes.atlassian.net/browse/ADSDEV-407