### PR TITLE
Bump alphaville-ui to 5.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
 		"tests"
 	],
 	"dependencies": {
-		"alphaville-ui": "^5.0.0",
+		"alphaville-ui": "^5.0.2",
 		"ftdomdelegate": "^4.0.0",
 		"o-dom": "o-dom#^2.0.0",
 		"hogan": "twitter/hogan.js#^3.0.2",


### PR DESCRIPTION
This fixes the icons of sharing buttons.