### PR TITLE
ADSDEV-603: Set uuid instead of guid

### DIFF
--- a/assets/js/lib/permutive.js
+++ b/assets/js/lib/permutive.js
@@ -14,7 +14,7 @@ document.body.addEventListener('oAds.initialised', () => {
 	const pageView = nPermutive.fromAdsApiV1ToPageView({ user, article });
 
 	nPermutive.identifyUser({
-		uuid: user && user.guid
+		uuid: user && user.uuid
 	});
 	pageView && pageView.page && (pageView.page.type = getPageViewType());
 	nPermutive.trackPageView(pageView);


### PR DESCRIPTION
Fix a mistake where User.guid was read instead of user.uuid