### PR TITLE
Remove @snyk/nodejs-runtime-agent

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -1,19 +1,5 @@
 #!/usr/bin/env node
 
- /**
- * Snyk runtime monitoring.
- *
- * Determines whether a vulnerable dependency is indeed being used at runtime in a way that can be exploited.
- *
- * @see https://snyk.io/docs/runtime-protection/
- */
-if (process.env.SNYK_PROJECT_ID) {
-	require('@snyk/nodejs-runtime-agent')({
-		projectId: process.env.SNYK_PROJECT_ID
-	});
-}
-
-
 /**
  * Module dependencies.
  */

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "@financial-times/express-web-service": "^3.3.1",
-    "@snyk/nodejs-runtime-agent": "^1.46.0",
     "alphaville-auth-middleware": "Financial-Times/alphaville-auth-middleware#1.5.1",
     "alphaville-express": "Financial-Times/alphaville-express#1.1.1",
     "alphaville-header-config": "Financial-Times/alphaville-header-config#1.2.0",


### PR DESCRIPTION
Ref. https://github.com/snyk/nodejs-runtime-agent#user-content-supported-nodejs-versions:

> The Node.js Runtime Agent is tested on Node 8 and Node 10. Other versions are unsupported.

Node v10 end-of-life is 30 Apr 2021.

When `next-search-page` first upgraded from Node v10 to v12, it experienced a memory leak. Investigations on that app indicated that the cause was `@snyk/nodejs-runtime-agent` dependency. The dependency was removed and a second attempt to upgrade to Node v12 did not experience the memory leak. See https://github.com/Financial-Times/next-search-page/pull/424 for more details.

Admittedly, this app is already on Node v12, and presumably not experiencing consistent memory leaks. However, as this dependency is now a known risk and is essentially an added extra on top of the `snyk` dev dependency (that scans the `package.json` dependencies for vulnerabilities rather than at runtime), it makes sense to remove it.

The decision to remove this dependency has been made on the following basis:
- It blocks us upgrading to a supported version of Node, forcing us to stay on an unsupported version.
- It would be pretty ironic to use a tool to denote whether a vulnerable dependency is being used at the cost of using an unsupported version of Node.
- While we can still use Snyk as we do for other repos (i.e. as a dev dependency that scans `package.json` files), this check for whether dependencies are definitely being used at runtime is an added extra that we can do without.