### PR TITLE
NOPS-613 Enable free text in job position and industry fields

### DIFF
--- a/views/joinForm.handlebars
+++ b/views/joinForm.handlebars
@@ -98,7 +98,7 @@
 					</span>
 					
 					<span class="o-forms-input o-forms-input--text">
-						<input type="text" name="jobTitle" value="{{user.demographics.position.description}}" disabled />
+						<input type="text" name="jobTitle" value="{{user.demographics.position.description}}"/>
 					</span>
 				</label>
 			</div>
@@ -110,7 +110,7 @@
 					</span>
 					
 					<span class="o-forms-input o-forms-input--text">
-						<input type="text" name="industry" value="{{user.demographics.industry.description}}" disabled />
+						<input type="text" name="industry" value="{{user.demographics.industry.description}}"/>
 					</span>
 				</label>
 			</div>


### PR DESCRIPTION
To mitigate issue where values are not pulling from user's account details. I have confirmed with stakeholders this is ok.

See: https://app.slack.com/client/T025C95MN/C042NBBTM/thread/C042NBBTM-1610290500.102900 for the conversation with Product Support about this

Note: there is no circle pipeline for this app hence the build error. The app needs manually promoting to heroku via a test app. I will check the changes work as expected in the test app before promoting to production.