### PR TITLE
Join process responsibility clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,45 @@ Install gulp globally:
 ```
 npm install -g gulp
 ```
+### Run locally
 
-### Install PostgreSQL (optional)
+Create environment variables by copying them from the Heroku app by running the following command (you will need to be logged into Heroku):
+
+```
+heroku config -s  >> .env --app av2-longroom-prod
+```
+
+Now install and run with
+
+```
+make run-dev
+```
+
+Under the hood `make run-dev`:
+- Uses `Heroku local` which installs npm modules, as well as bower install and gulp build.
+- Adds a `SKIP_AUTH=true` environment variable which allows you to view content without hitting the barrier. This is needed because when running the app locally there's no Fastly service in front of the app to set the Decision header from the Access service.
+
+View the app:
+`http://local.ft.com:5001/longroom`
+
+Note, you will need to be on `http`.
+
+### Additional quirks of working locally: Joining/license allocation
+
+If you have to work on the joining/license allocation area, including the join form, the app will need to have access to the `FTSession_s` in order to access the User API service. Because the app runs locally over `http` you will need to manually copy the value of `FTSession_s` into a cookie with the same name, but available on `http`, or even [manually set the cookie value directly in the code here](https://github.com/Financial-Times/alphaville-longroom/blob/master/lib/controllers/user.js#L28).
+
+See below `Admin` section if you are working on the join form and want to test repeadlty with the same user.
+
+### Additional quirks of working locally: Admin
+
+The Admin page allows the Alphaville team to accept and reject join requests. If you are testing this functionality it's useful to be able to reject requests so that you can submit multiple join requests with the same user. To access this page locally you need to [comment out the line of code that checks whether a user is admin](https://github.com/Financial-Times/alphaville-longroom/blob/master/routes/adminRouter.js#L5).
+
+**Take Note:** When you visit the admin page locally you will see production user requests to Alphaville and have the power to accept and reject them (which you should leave to the Alphaville Editorial team). Please navigate with care.
+
+### Working locally on the database
+If you want to work locally on the databse you will need to install PostgreSQL.
 
 **Skip this step if you are not working on the database itself - you can just use the database from the TEST environment.**
-
-However, if you need to work on the database locally, you should have one installed on your machine as well.
 
 Follow the official documentation on how to download and install postgreSQL locally: https://www.postgresql.org/download/
 The easiest way is to import a dump from the TEST database.
@@ -44,52 +77,10 @@ Define the local database URL
 DATABASE_URL="postgres://postgres@database:5432/longroom"
 ```
 
-### Run locally
-
-Create environment variables by copying them from the Heroku app by running the following command (you will need to be logged into Heroku):
-
-```
-heroku config -s  >> .env --app av2-longroom-prod
-```
-now install and run with
-
-```
-make run-dev
-```
-
-(Under the hood `make run-dev` uses `Heroku local` which installs npm modules, as well as bower install and gulp build.)
-
-Visit `http://local.ft.com:5001/longroom` to see the app running locally. Note, you will need to be on `http`. 
-
-The build integrates origami build tools, so before this please make sure you have all the prerequisites needed for it: https://github.com/Financial-Times/origami-build-tools#usage
-
-
-
-## Start the app
-
-Run the following:
-
-```
-heroku local
-```
 
 ## Deployment
 
-Alphaville Longroom does not have a CI deployment set up. Once you have tested everything, go to heroku and deploy from the deployment tab for `av2-longroom-test` and then `av2-longroom-prod`.
-
-### Article access
-
-In order you to be able to access articles without getting the barrier, you will need 2 things:
-
-Set up a URL in the hosts file that points local.ft.com to the localhost
-Add SKIP_AUTH=true environment variable (this is needed because running the app locally there's no fastly service in front of the app to set the Decision header from the Access service).
-
-### Joining/license allocation
-
-If you have to work on the joining/license allocation area, the app will need to have access to the `FTSession_s` in order to access the User API service. There are 2 ways you could achieve this:
-
-1. run the app locally on https
-2. Manually copy the value of `FTSession_s` into a cookie with the same name, but available on `http` as well.
+Alphaville Longroom does not have a CI deployment set up. Once you have tested everything, go to heroku and deploy from the github in the deployment tab for `av2-longroom-test` and then, if the test app looks ok, promote to on the Heroku pipeline dashboard `av2-longroom-prod`.
 
 ### Rotating Keys
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ npm install -g gulp
 
 ### Install PostgreSQL (optional)
 
-You can skip this step if you are not working on the database itself and you can just use the database from the TEST environment.
+**Skip this step if you are not working on the database itself - you can just use the database from the TEST environment.**
+
 However, if you need to work on the database locally, you should have one installed on your machine as well.
 
 Follow the official documentation on how to download and install postgreSQL locally: https://www.postgresql.org/download/
@@ -45,21 +46,20 @@ DATABASE_URL="postgres://postgres@database:5432/longroom"
 
 ### Run locally
 
-You'll need to create environment variable
-
-The fastest way to do this is to run the following assuming your are logged in into heroku
+Create environment variables by copying them from the Heroku app by running the following command (you will need to be logged into Heroku):
 
 ```
 heroku config -s  >> .env --app av2-longroom-prod
 ```
-
-Now run the initial npm install on the app
+now install and run with
 
 ```
-npm install
+make run-dev
 ```
 
-This will not just install npm modules, but automatically run bower install and gulp build as well.
+(Under the hood `make run-dev` uses `Heroku local` which installs npm modules, as well as bower install and gulp build.)
+
+Visit `http://local.ft.com:5001/longroom` to see the app running locally. Note, you will need to be on `http`. 
 
 The build integrates origami build tools, so before this please make sure you have all the prerequisites needed for it: https://github.com/Financial-Times/origami-build-tools#usage
 

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -51,35 +51,34 @@ const getUserFormModel = (userUuid, access_token) => {
 };
 
 const addJoinRequest = (user_id, userProfile, formData) => {
-	try {
-		var {
-			    email,
-			    primaryTelephone: phone,
-			    firstName: first_name,
-			    lastName: last_name,
-			    demographics: {
-				    responsibility: {
-					    description: responsibility
-				    }
-			    }
-			} = userProfile.user;
-
-	} catch(e) {
-		throw new IncompleteUserDataError();
-	}
-
 	let {
 		location,
 		description,
 		summary,
 		industry,
-		jobTitle
+		jobTitle,
 	} = formData;
 
-	return db.user.find(user_id)
-		.then(user => {
-			if (user) {
-				return db.user.rejoin({
+	// use userProfile for these details so that we don't send personal data in the form
+	let {
+		email,
+		primaryTelephone: phone,
+		firstName: first_name,
+		lastName: last_name,
+		demographics: {
+			responsibility: userProfileResponsibility
+		}
+	} = userProfile.user;
+
+	let responsibility = userProfileResponsibility ? userProfileResponsibility.description : "";
+
+	if (!first_name || !last_name || !email) {
+		throw new IncompleteUserDataError();
+	}
+
+	return db.user.find(user_id).then((user) => {
+		if (user) {
+			return db.user.rejoin({
 					user_id,
 					location,
 					description,
@@ -94,27 +93,27 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 					position: jobTitle && crypto.encrypt(jobTitle),
 					responsibility: responsibility && crypto.encrypt(responsibility)
 				});
-			} else {
-				return db.user.join(
-					{
-						user_id,
-						location,
-						description,
-						summary,
-					},
-					{
-						user_id,
-						email: email && crypto.encrypt(email),
-						phone: phone && crypto.encrypt(phone),
-						first_name: first_name && crypto.encrypt(first_name),
-						last_name: last_name && crypto.encrypt(last_name),
-						industry: industry && crypto.encrypt(industry),
-						position: jobTitle && crypto.encrypt(jobTitle),
-						responsibility: responsibility && crypto.encrypt(responsibility),
-					}
-				);
-			}
-		});
+		} else {
+			return db.user.join(
+				{
+					user_id,
+					location,
+					description,
+					summary,
+				},
+				{
+					user_id,
+					email: email && crypto.encrypt(email),
+					phone: phone && crypto.encrypt(phone),
+					first_name: first_name && crypto.encrypt(first_name),
+					last_name: last_name && crypto.encrypt(last_name),
+					industry: industry && crypto.encrypt(industry),
+					position: jobTitle && crypto.encrypt(jobTitle),
+					responsibility: responsibility && crypto.encrypt(responsibility),
+				}
+			);
+		}
+	});
 };
 
 const addPseudonymToLongroom = (user_id, formData) => {
@@ -266,7 +265,7 @@ const join = (req, res, next) => {
 		.catch(err => {
 			if (err instanceof IncompleteUserDataError) {
 				res.render('nonMemberMessage', {
-					message: '<strong>Please visit <a href="https://registration.ft.com/registration/selfcare/">My Account</a> to input your job, industry and responsibility, then you can apply for Longroom membership</strong>'
+					message: '<strong>Please visit <a href="https://registration.ft.com/registration/selfcare/">My Account</a> to input your first name, last name, and email, then you can apply for Longroom membership</strong>'
 				});
 			} else {
 				next(err);

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -58,16 +58,6 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 			    firstName: first_name,
 			    lastName: last_name,
 			    demographics: {
-				    industry: {
-					    description: industry
-				    }
-			    },
-			    demographics: {
-				    position: {
-					    description: position
-				    }
-			    },
-			    demographics: {
 				    responsibility: {
 					    description: responsibility
 				    }
@@ -79,10 +69,12 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 	}
 
 	let {
-		    location,
-		    description,
-		    summary
-	    } = formData;
+		location,
+		description,
+		summary,
+		industry,
+		jobTitle
+	} = formData;
 
 	return db.user.find(user_id)
 		.then(user => {
@@ -99,25 +91,28 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 					first_name: first_name && crypto.encrypt(first_name),
 					last_name: last_name && crypto.encrypt(last_name),
 					industry: industry && crypto.encrypt(industry),
-					position: position && crypto.encrypt(position),
+					position: jobTitle && crypto.encrypt(jobTitle),
 					responsibility: responsibility && crypto.encrypt(responsibility)
 				});
 			} else {
-				return db.user.join({
-					user_id,
-					location,
-					description,
-					summary
-				}, {
-					user_id,
-					email: email && crypto.encrypt(email),
-					phone: phone && crypto.encrypt(phone),
-					first_name: first_name && crypto.encrypt(first_name),
-					last_name: last_name && crypto.encrypt(last_name),
-					industry: industry && crypto.encrypt(industry),
-					position: position && crypto.encrypt(position),
-					responsibility: responsibility && crypto.encrypt(responsibility)
-				});
+				return db.user.join(
+					{
+						user_id,
+						location,
+						description,
+						summary,
+					},
+					{
+						user_id,
+						email: email && crypto.encrypt(email),
+						phone: phone && crypto.encrypt(phone),
+						first_name: first_name && crypto.encrypt(first_name),
+						last_name: last_name && crypto.encrypt(last_name),
+						industry: industry && crypto.encrypt(industry),
+						position: jobTitle && crypto.encrypt(jobTitle),
+						responsibility: responsibility && crypto.encrypt(responsibility),
+					}
+				);
 			}
 		});
 };

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -56,7 +56,7 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 		description,
 		summary,
 		industry,
-		jobTitle,
+		jobTitle
 	} = formData;
 
 	// use userProfile for these details so that we don't send personal data in the form
@@ -76,9 +76,10 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 		throw new IncompleteUserDataError();
 	}
 
-	return db.user.find(user_id).then((user) => {
-		if (user) {
-			return db.user.rejoin({
+	return db.user.find(user_id)
+		.then(user => {
+			if (user) {
+				return db.user.rejoin({
 					user_id,
 					location,
 					description,
@@ -93,27 +94,27 @@ const addJoinRequest = (user_id, userProfile, formData) => {
 					position: jobTitle && crypto.encrypt(jobTitle),
 					responsibility: responsibility && crypto.encrypt(responsibility)
 				});
-		} else {
-			return db.user.join(
-				{
-					user_id,
-					location,
-					description,
-					summary,
-				},
-				{
-					user_id,
-					email: email && crypto.encrypt(email),
-					phone: phone && crypto.encrypt(phone),
-					first_name: first_name && crypto.encrypt(first_name),
-					last_name: last_name && crypto.encrypt(last_name),
-					industry: industry && crypto.encrypt(industry),
-					position: jobTitle && crypto.encrypt(jobTitle),
-					responsibility: responsibility && crypto.encrypt(responsibility),
-				}
-			);
-		}
-	});
+			} else {
+				return db.user.join(
+					{
+						user_id,
+						location,
+						description,
+						summary,
+					},
+					{
+						user_id,
+						email: email && crypto.encrypt(email),
+						phone: phone && crypto.encrypt(phone),
+						first_name: first_name && crypto.encrypt(first_name),
+						last_name: last_name && crypto.encrypt(last_name),
+						industry: industry && crypto.encrypt(industry),
+						position: jobTitle && crypto.encrypt(jobTitle),
+						responsibility: responsibility && crypto.encrypt(responsibility),
+					}
+				);
+			}
+		});
 };
 
 const addPseudonymToLongroom = (user_id, formData) => {

--- a/views/joinForm.handlebars
+++ b/views/joinForm.handlebars
@@ -27,7 +27,6 @@
 				</label>
 			</div>
 
-
 			<div data-o-grid-colspan="9">
 				<label class="o-forms-field" for="firstName">
 					<span class="o-forms-title">
@@ -91,14 +90,43 @@
 				</div>
 			{{/if}}
 
+			{{#if errors.jobTitle}}
+				<div data-o-grid-colspan="9">
+					<label class="o-forms-field" for="jobTitle">
+						<span class="o-forms-title">
+							<span class="o-forms-title__main">Job Title *</span>
+						</span>
+
+						<span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+							<input required type="text" name="location" value="{{form.jobTitle}}" />
+							{{#each errors.jobTitle}}
+								<div class="o-forms-input__error">{{this}}</div>
+							{{/each}}
+						</span>
+					</label>
+				</div>
+			{{else}}
+				<div data-o-grid-colspan="9">
+					<label class="o-forms-field" for="jobTitle">
+						<span class="o-forms-title">
+							<span class="o-forms-title__main">Job Title *</span>
+						</span>
+						
+						<span class="o-forms-input o-forms-input--text o-forms-input--invalid">
+							<input required type="text" name="jobTitle" value="{{user.demographics.position.description}}"/>
+						</span>
+					</label>
+				</div>
+			{{/if}}
+
 			<div data-o-grid-colspan="9">
-				<label class="o-forms-field" for="jobTitle">
+				<label class="o-forms-field" for="phone">
 					<span class="o-forms-title">
-						<span class="o-forms-title__main">Job Title</span>
+						<span class="o-forms-title__main">Daytime Phone Number</span>
 					</span>
 					
 					<span class="o-forms-input o-forms-input--text">
-						<input type="text" name="jobTitle" value="{{user.demographics.position.description}}"/>
+						<input type="text" name="phone" value="{{user.primaryTelephone}}" disabled />
 					</span>
 				</label>
 			</div>
@@ -111,18 +139,6 @@
 					
 					<span class="o-forms-input o-forms-input--text">
 						<input type="text" name="industry" value="{{user.demographics.industry.description}}"/>
-					</span>
-				</label>
-			</div>
-
-			<div data-o-grid-colspan="9">
-				<label class="o-forms-field" for="phone">
-					<span class="o-forms-title">
-						<span class="o-forms-title__main">Daytime Phone Number</span>
-					</span>
-					
-					<span class="o-forms-input o-forms-input--text">
-						<input type="text" name="phone" value="{{user.primaryTelephone}}" disabled />
 					</span>
 				</label>
 			</div>


### PR DESCRIPTION
**Add clarity around how the responsibility value is set when a user submits the join form:**
It is not present on the form and is instead taken from the user profile returned from the session api. If it is not present on the users profile, the form currently errors though it is difficult for a user to see why (i.e. it threw me enough that I didn't even notice it was causing me a problem in my last two PRs 😬 ). It is not a required field, so instead set the value to an empty string if it is not present on the users profile. 

**Tidy up the form handlebars:**
Add error handling to those fields that used to be disabled but are now free text and required

see
https://github.com/Financial-Times/alphaville-longroom/pull/85
https://github.com/Financial-Times/alphaville-longroom/pull/84

Form now:
![local ft com_5001_longroom_user_join](https://user-images.githubusercontent.com/17846996/106476206-b806dd00-649e-11eb-8709-35d4604d2158.png)
