### PR TITLE
NOPS-973 update ssl db property

### DIFF
--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -41,7 +41,7 @@ const options = {
 
 const pgp = require('pg-promise')(options);
 
-const db = pgp(process.env.DATABASE_URL + (process.env.DATABASE_SSL === 'true' ? '?ssl=true' : ''));
+const db = pgp(process.env.DATABASE_URL + (process.env.DATABASE_SSL === 'true' ? '?ssl[rejectUnauthorized]=false' : ''));
 
 module.exports = {
 	pgp,


### PR DESCRIPTION
Users cannot access Longroom.
![image](https://user-images.githubusercontent.com/25018001/129536483-1b3ec195-da83-4c68-ba7c-0b5cf8532b2a.png)

Heroku now wants 
```
  ssl: {
    rejectUnauthorized: false
  }
```
instead of `ssl: true` on the connection object - https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-node-js

This PR updates the value of `ssl`. 