### PR TITLE
update ssl db property on connection string

### DIFF
--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -41,7 +41,9 @@ const options = {
 
 const pgp = require('pg-promise')(options);
 
-const db = pgp(process.env.DATABASE_URL + (process.env.DATABASE_SSL === 'true' ? '?ssl=true' : ''));
+const db = pgp({
+	connectionString: process.env.DATABASE_URL + (process.env.DATABASE_SSL === 'true' ? '?sslmode=no-verify' : ''),
+});
 
 module.exports = {
 	pgp,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node-fetch": "^1.7.3",
     "origami-build-tools": "^7.0.0",
     "path": "^0.12.7",
-    "pg-promise": "^5.4.3",
+    "pg-promise": "^10.11.0",
     "request": "^2.74.0",
     "request-promise": "^4.1.1",
     "sanitize-html": "^1.13.0",


### PR DESCRIPTION
A new improved solution to https://github.com/Financial-Times/alphaville-longroom/pull/106 

Users cannot access Longroom.
![image](https://user-images.githubusercontent.com/25018001/129536483-1b3ec195-da83-4c68-ba7c-0b5cf8532b2a.png)

Heroku now wants 
```
  ssl: {
    rejectUnauthorized: false
  }
```
instead of `ssl: true` on the connection object - https://devcenter.heroku.com/articles/heroku-postgresql#connecting-in-node-js

This PR updates the value of `ssl`, but since it's a connection string it will use `ssl=no-verify` [as per the docs](https://github.com/brianc/node-postgres/tree/master/packages/pg-connection-string#tcp-connections).