### PR TITLE
Remove the sending of approve/reject emails

### DIFF
--- a/lib/controllers/admin.js
+++ b/lib/controllers/admin.js
@@ -2,7 +2,6 @@ const db = require('../services/db').db;
 const moment = require('moment-timezone');
 const crypto = require('../services/crypto');
 const als = require('../services/als');
-const mailer = require('../services/mailer');
 const _ = require('lodash');
 
 const decryptUser = user => {
@@ -23,15 +22,13 @@ const approveUser = user_id => {
 			}
 		})
 		.then(() => db.user.updateUserStatus(user_id, 'approved'))
-		.then(() => db.userDetails.deleteById(user_id))
-		.then(() => mailer.sendApproved(user_id));
+		.then(() => db.userDetails.deleteById(user_id));
 };
 
 const rejectUser = user_id => {
 	return db.user.updateUserStatus(user_id, 'rejected')
 		.then(db.userDetails.deleteById(user_id))
-		.then(db.displayNames.deleteByUserId(user_id))
-		.then(() => mailer.sendRejected(user_id));
+		.then(db.displayNames.deleteByUserId(user_id));
 };
 
 const suspendUser = user_id => {


### PR DESCRIPTION
Now that we are no longer accepting new users we can remove the ability to send emails to users if they have been accepted or rejected.

This is important right now because the send api we are using is being decommed as well and the api key was potentially leaked so we would rather delete it then rotate it

Note: This is a lazy was to remove the use of the email sending. I don't want to worry about doing lots of clean up when this service will be shut down soon